### PR TITLE
feat(dgm): Implement initial DGM meta-loop with placeholders

### DIFF
--- a/dgm_kernel/meta_loop.py
+++ b/dgm_kernel/meta_loop.py
@@ -1,0 +1,234 @@
+# dgm_kernel/meta_loop.py
+"""
+Darwin Gödel Machine – self-improvement meta-loop (async capable)
+
+TODOs are marked ▼
+"""
+
+from __future__ import annotations
+import asyncio, importlib, logging, time, json # Added json import
+import redis # Changed from 'from redis import Redis'
+from pathlib import Path
+# from redis import Redis # Original import
+from llm_sidecar.reward import proofable_reward
+
+log = logging.getLogger(__name__)
+
+REDIS = redis.Redis(host="redis", port=6379, decode_responses=True) # Updated instantiation
+PATCH_QUEUE = "dgm:patch_queue"        # ← incoming JSON patches
+TRACE_QUEUE = "dgm:recent_traces"      # ← recent trading traces (jsonl)
+APPLIED_LOG  = "dgm:applied_patches"   # ← audit trail
+
+# ────────────────────────────────────────────────────────────────────────────
+# ▼ 1.  fetch_recent_traces()  (pull N traces from Redis)
+# ▼ 2.  generate_patch()       (call LLM / α-search to propose code diff)
+# ▼ 3.  apply_patch()          (load diff, patch in-place, hot-reload module)
+# ▼ 4.  rollback_if_bad()      (revert if reward ↓ or errors ↑)
+# ────────────────────────────────────────────────────────────────────────────
+
+async def fetch_recent_traces(n: int = 100) -> list[dict]:
+    """Pop the newest N traces for evaluation. Handles JSON decoding errors."""
+    traces = []
+    try:
+        # Efficiently get N items using pipeline or Lua script if supported for async,
+        # or loop rpop if not. For simplicity with sync Redis client in async context,
+        # direct rpop loop is used here. Consider redis-py's async client for true async.
+        raw_traces = []
+        for _ in range(n):
+            j = REDIS.rpop(TRACE_QUEUE)
+            if j is None:  # rpop returns None if the list is empty
+                break
+            raw_traces.append(j)
+
+        if not raw_traces:
+            return [] # Return empty list if no traces were fetched
+
+        for i, trace_str in enumerate(raw_traces):
+            try:
+                traces.append(json.loads(trace_str))
+            except json.JSONDecodeError as e:
+                log.error(f"Failed to decode JSON for trace: {trace_str}. Error: {e}. Trace index: {i}")
+                # Optionally, could add malformed trace to a separate Redis list for inspection
+                # REDIS.lpush("dgm:malformed_traces", trace_str)
+
+        if traces: # Log only if some traces were successfully parsed
+            log.info(f"Fetched {len(traces)} traces successfully, encountered {len(raw_traces) - len(traces)} decoding errors.")
+        elif raw_traces: # Log if raw traces were fetched but none could be parsed
+            log.warning(f"Fetched {len(raw_traces)} raw traces, but all failed to decode.")
+        # If raw_traces is empty, nothing is logged by these conditions, which is fine.
+
+    except redis.exceptions.RedisError as e:
+        log.error(f"Redis error while fetching traces: {e}")
+        # Depending on the severity, could raise or return empty list
+        return [] # Or handle more gracefully
+    except Exception as e: # Catch any other unexpected errors
+        log.error(f"Unexpected error in fetch_recent_traces: {e}")
+        return []
+
+    return traces
+
+async def generate_patch(traces: list[dict]) -> dict | None: # Return type updated to include None
+    """
+    Placeholder for LLM / search routine to emit a JSON patch.
+    ▼ TODO: Replace with actual patch generation logic.
+    """
+    if not traces:
+        log.warning("generate_patch called with no traces, skipping.")
+        return None
+
+    log.info(f"generate_patch called with {len(traces)} traces. Generating a placeholder patch.")
+
+    # This is a dummy patch. In a real scenario, this would be dynamically generated.
+    # The 'before' content should ideally be fetched from the actual target file.
+    # For this placeholder, we'll use a simplified 'before'.
+    # IMPORTANT: The target file 'osiris_policy/strategy.py' must exist or be creatable by _apply_patch.
+    # For initial testing, _apply_patch can create it.
+
+    # Ensure the target directory and a placeholder 'before' content exists for the dummy patch to be meaningful.
+    # This part would normally be handled by fetching current content of `patch_target_file`.
+    # For this placeholder, we assume `_apply_patch` can handle creating the file if it doesn't exist,
+    # and `_rollback` can write back the 'before' state.
+
+    patch_target_file = Path("osiris_policy/strategy.py")
+    current_content = ""
+    try:
+        if patch_target_file.exists():
+            current_content = patch_target_file.read_text()
+        else:
+            # If the file doesn't exist, we can prime it with some initial content
+            # or ensure _apply_patch creates it. For simplicity, assume it might not exist.
+            log.info(f"Target file {patch_target_file} does not exist. 'before' will be empty for this placeholder.")
+            # It's also possible to create a dummy file here for the placeholder to work more realistically.
+            # patch_target_file.parent.mkdir(parents=True, exist_ok=True)
+            # patch_target_file.write_text("# Initial placeholder content
+")
+            # current_content = "# Initial placeholder content
+"
+    except Exception as e:
+        log.error(f"Error reading target file {patch_target_file} for 'before' state: {e}")
+        # Decide how to handle: skip patch, or use empty 'before'
+        # return None
+
+    placeholder_patch = {
+        "target": str(patch_target_file), # Ensure it's a string
+        "before": current_content,
+        "after": current_content + "\n# Placeholder patch: DGM was here at " + time.strftime("%Y-%m-%d %H:%M:%S") + "\n",
+        "rationale": "This is a placeholder patch generated by the DGM meta_loop for testing purposes."
+    }
+
+    log.info(f"Generated placeholder patch: {placeholder_patch}")
+    # Simulate some processing time
+    await asyncio.sleep(1)
+    return placeholder_patch
+
+async def _prove_patch(patch: dict) -> bool:
+    """
+    Placeholder for submitting patch to a verifier daemon.
+    ▼ TODO: Replace with actual verifier daemon interaction.
+    """
+    if not patch:
+        log.warning("_prove_patch called with no patch, skipping.")
+        return False
+
+    log.info(f"Submitting patch for {patch.get('target')} to verifier daemon (placeholder).")
+    log.debug(f"Patch content: {patch}") # Log full patch at debug level
+
+    # Simulate verifier interaction time
+    await asyncio.sleep(0.5)
+
+    # Placeholder: Assume patch is always approved
+    log.info(f"Patch for {patch.get('target')} approved by verifier daemon (placeholder).")
+    return True
+
+def _apply_patch(patch: dict) -> bool:
+    """
+    Atomically write patch['after'] into patch['target'] on disk,
+    then `importlib.reload()` the module in-memory.
+    Return True on success.
+    """
+    tgt = Path(patch["target"])
+    # Create parent directories if they don't exist
+    tgt.parent.mkdir(parents=True, exist_ok=True)
+    tgt.write_text(patch["after"])
+    importlib.invalidate_caches()
+    # Ensure the module path is in a format importlib can use
+    # e.g., osiris_policy.strategy if target is osiris_policy/strategy.py
+    module_name = str(tgt.with_suffix('')).replace('/', '.')
+    try:
+        module = importlib.import_module(module_name)
+        importlib.reload(module)
+    except ModuleNotFoundError:
+        # This can happen if the module is being created for the first time
+        # or if it's not in a package.
+        # Attempt to load it based on its path directly if it's a new top-level module
+        # This part can be tricky and might need adjustment based on project structure
+        log.warning(f"Module {module_name} not found directly, attempting to load spec.")
+        try:
+            spec = importlib.util.spec_from_file_location(module_name, str(tgt))
+            if spec and spec.loader:
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+                # This doesn't reload it into sys.modules in a standard way for subsequent reloads
+                # but makes its code run. For DGM, this might be enough for a first patch.
+            else:
+                raise ImportError(f"Could not load spec for {module_name} from {tgt}")
+        except Exception as e:
+            log.error(f"Error loading module {module_name} after writing patch: {e}")
+            return False
+
+    return True
+
+async def meta_loop():
+    """Main async supervisor loop (runs forever)."""
+    while True:
+        traces = await fetch_recent_traces()
+        if not traces:
+            await asyncio.sleep(5); continue
+
+        patch = await generate_patch(traces)
+        if not patch:
+            log.info("No patch generated, continuing.")
+            continue
+
+        # ▼ Add call to _prove_patch here
+        patch_is_proven = await _prove_patch(patch)
+        if not patch_is_proven:
+            log.warning(f"Patch for {patch.get('target')} was not approved by verifier, skipping application.")
+            # Optionally, add to a different Redis log for rejected patches
+            # REDIS.lpush("dgm:rejected_patches", json.dumps(patch))
+            continue
+
+        if _apply_patch(patch):
+            # Evaluate reward on the same trace batch
+            new_r = sum(proofable_reward(t, {}) for t in traces)
+            if new_r >= 0:   # simple non-regression gate for now
+                REDIS.lpush(APPLIED_LOG, json.dumps(patch | {"reward": new_r}))
+                log.info("Patch applied ✔️  reward=%.4f", new_r)
+            else:
+                log.warning("Patch rolled back, reward=%.4f", new_r)
+                _rollback(patch)
+        else:
+            log.error(f"Failed to apply patch for target: {patch.get('target')}")
+            # _rollback(patch) # Consider if rollback is safe if apply itself failed.
+
+def _rollback(patch: dict):
+    """Rolls back the patch by writing the 'before' content to the target file and reloading the module."""
+    tgt = Path(patch["target"])
+    tgt.write_text(patch["before"])
+    importlib.invalidate_caches()
+    module_name = str(tgt.with_suffix('')).replace('/', '.')
+    try:
+        module = importlib.import_module(module_name)
+        importlib.reload(module)
+        log.info(f"Rolled back {patch['target']} successfully.")
+    except Exception as e:
+        # Log error during rollback, but proceed as the file is reverted.
+        log.error(f"Error reloading module {module_name} during rollback: {e}")
+
+
+# Entrypoint for standalone container / CLI
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    # Ensure json is imported if this script is run directly
+    import json
+    asyncio.run(meta_loop())

--- a/tests/dgm_kernel/__init__.py
+++ b/tests/dgm_kernel/__init__.py
@@ -1,0 +1,1 @@
+# This file makes Python treat the directory tests/dgm_kernel as a package.

--- a/tests/dgm_kernel/test_meta_loop.py
+++ b/tests/dgm_kernel/test_meta_loop.py
@@ -1,0 +1,229 @@
+import asyncio
+import json
+import logging
+from pathlib import Path
+from unittest import mock # Python's built-in mock library
+
+import pytest
+import fakeredis # Needs to be installed: pip install fakeredis
+
+# Modules to be tested
+from dgm_kernel import meta_loop
+
+# Configure logging for tests (optional, but can be helpful)
+logging.basicConfig(level=logging.DEBUG)
+log = logging.getLogger(__name__)
+
+@pytest.fixture
+def mock_redis_server():
+    # This fixture provides a fakeredis server instance if needed,
+    # but often, the decorator is enough.
+    server = fakeredis.FakeServer()
+    server.connected = True # Ensure it appears connected
+    return server
+
+@pytest.fixture
+def fake_redis(mock_redis_server):
+    # Use fakeredis.FakeStrictRedis for type compatibility with redis.Redis
+    # The `decode_responses=True` is important to match the application code.
+    r = fakeredis.FakeStrictRedis(server=mock_redis_server, decode_responses=True)
+    # Ensure the connection is explicitly "established"
+    r.ping()
+    return r
+
+@pytest.fixture(autouse=True)
+def patch_redis_client(monkeypatch, fake_redis):
+    """Autouse fixture to replace meta_loop.REDIS with our fake_redis instance."""
+    monkeypatch.setattr(meta_loop, "REDIS", fake_redis)
+    # Also patch any direct instantiations if they exist elsewhere, though meta_loop uses a global.
+    # If meta_loop.py creates Redis client inside functions (it doesn't currently),
+    # that would need more specific patching (e.g., @mock.patch('dgm_kernel.meta_loop.redis.Redis')).
+
+
+# --- Test Cases for fetch_recent_traces ---
+
+@pytest.mark.asyncio
+async def test_fetch_recent_traces_empty_queue(fake_redis):
+    log.info("Testing fetch_recent_traces with an empty queue.")
+    traces = await meta_loop.fetch_recent_traces(n=5)
+    assert len(traces) == 0
+    log.info("Test passed: fetch_recent_traces with empty queue returned 0 traces.")
+
+@pytest.mark.asyncio
+async def test_fetch_recent_traces_fetches_n_items(fake_redis):
+    log.info("Testing fetch_recent_traces fetches N items.")
+    trace_data = [{"id": i, "data": f"trace_{i}"} for i in range(10)]
+    # Push to the TRACE_QUEUE (items are pushed left, popped right in meta_loop)
+    for trace in trace_data:
+        fake_redis.lpush(meta_loop.TRACE_QUEUE, json.dumps(trace))
+
+    fetched_traces = await meta_loop.fetch_recent_traces(n=7)
+    assert len(fetched_traces) == 7
+    # Redis RPUSH/RPOP means LIFO, but lpush/rpop is FIFO if rpop is from the "end" of list
+    # The code uses rpop, which takes from the tail. lpush adds to head.
+    # So, if we lpush 0,1,2...9, then rpop will give 0, then 1, ...
+    # The order in fetched_traces should be trace_data[0] to trace_data[6]
+    for i in range(7):
+        assert fetched_traces[i]["id"] == i
+
+    # Check remaining items in queue
+    assert fake_redis.llen(meta_loop.TRACE_QUEUE) == 3
+    log.info("Test passed: fetch_recent_traces fetched N items correctly.")
+
+@pytest.mark.asyncio
+async def test_fetch_recent_traces_less_than_n_items_available(fake_redis):
+    log.info("Testing fetch_recent_traces with less than N items available.")
+    trace_data = [{"id": i, "data": f"trace_{i}"} for i in range(3)]
+    for trace in trace_data:
+        fake_redis.lpush(meta_loop.TRACE_QUEUE, json.dumps(trace))
+
+    fetched_traces = await meta_loop.fetch_recent_traces(n=5)
+    assert len(fetched_traces) == 3
+    for i in range(3):
+        assert fetched_traces[i]["id"] == i
+    assert fake_redis.llen(meta_loop.TRACE_QUEUE) == 0
+    log.info("Test passed: fetch_recent_traces handled less than N items correctly.")
+
+@pytest.mark.asyncio
+async def test_fetch_recent_traces_json_decode_error(fake_redis, caplog):
+    log.info("Testing fetch_recent_traces with a JSON decode error.")
+    fake_redis.lpush(meta_loop.TRACE_QUEUE, json.dumps({"id": 1, "data": "valid_trace"}))
+    fake_redis.lpush(meta_loop.TRACE_QUEUE, "this_is_not_json")
+    fake_redis.lpush(meta_loop.TRACE_QUEUE, json.dumps({"id": 3, "data": "another_valid_trace"}))
+
+    # We pushed 3 items, rpop will fetch in reverse order of lpush if we think of it as stack.
+    # Or, if lpush = head, rpop = tail:
+    # Pushed: {"id":3}, "not_json", {"id":1}  ( {"id":1} is at tail)
+    # Fetched: {"id":1}, then "not_json" (error), then {"id":3}
+
+    caplog.clear() # Clear previous logs
+    with caplog.at_level(logging.ERROR):
+        fetched_traces = await meta_loop.fetch_recent_traces(n=3)
+
+    assert len(fetched_traces) == 2 # Should skip the invalid one
+    assert fetched_traces[0]["id"] == 1 # from rpop
+    assert fetched_traces[1]["id"] == 3 # from rpop
+
+    assert any("Failed to decode JSON for trace: this_is_not_json" in message for message in caplog.messages)
+    log.info("Test passed: fetch_recent_traces handled JSON decode error correctly.")
+
+# --- Placeholder for meta_loop tests ---
+# These will be more complex and require mocking generate_patch, _prove_patch, _apply_patch,
+# and llm_sidecar.reward.proofable_reward
+
+@pytest.mark.asyncio
+@mock.patch('dgm_kernel.meta_loop.generate_patch')
+@mock.patch('dgm_kernel.meta_loop._prove_patch')
+@mock.patch('dgm_kernel.meta_loop._apply_patch')
+@mock.patch('dgm_kernel.meta_loop.proofable_reward') # Path to proofable_reward
+@mock.patch('asyncio.sleep', return_value=None) # Mock sleep to speed up test
+async def test_meta_loop_applies_good_patch(
+    self, mock_sleep, mock_proofable_reward, mock_apply_patch,
+    mock_prove_patch, mock_generate_patch, fake_redis, tmp_path
+):
+    log.info("Testing meta_loop applies a good patch.")
+    # Setup:
+    # 1. Populate TRACE_QUEUE with some traces
+    trace_1 = {"id": "trace1", "value": 100}
+    fake_redis.lpush(meta_loop.TRACE_QUEUE, json.dumps(trace_1))
+
+    # 2. Configure mocks:
+    #   - generate_patch returns a valid patch
+    #   - _prove_patch returns True
+    #   - _apply_patch returns True
+    #   - proofable_reward returns a positive value
+
+    # Ensure target file for patch exists for 'before' content in generate_patch
+    # and for apply/rollback.
+    # We use tmp_path provided by pytest for temporary file operations.
+    target_file_path = tmp_path / "osiris_policy" / "strategy.py"
+    target_file_path.parent.mkdir(parents=True, exist_ok=True)
+    initial_content = "# Initial strategy content\n"
+    target_file_path.write_text(initial_content)
+
+    test_patch = {
+        "target": str(target_file_path),
+        "before": initial_content,
+        "after": initial_content + "# Patched by DGM\n",
+        "rationale": "Test rationale"
+    }
+    mock_generate_patch.return_value = asyncio.Future()
+    mock_generate_patch.return_value.set_result(test_patch)
+
+    mock_prove_patch.return_value = asyncio.Future()
+    mock_prove_patch.return_value.set_result(True)
+
+    # _apply_patch is synchronous in the code
+    mock_apply_patch.return_value = True
+
+    # proofable_reward is synchronous
+    mock_proofable_reward.return_value = 1.0 # Positive reward
+
+    # Run meta_loop for one iteration (or a controlled number)
+    # We need to run it in a way that it can be cancelled after one cycle for the test
+    # or rely on mock_generate_patch, etc. to control flow.
+    # For this test, we'll let it run once by controlling inputs and then check results.
+
+    # To make it run "once" effectively for this test case:
+    # - Provide one trace.
+    # - mock_generate_patch will be called once.
+    # - Then, if we want to stop, we could make generate_patch raise an exception
+    #   on subsequent calls, or make fetch_recent_traces return empty.
+    # For now, let's assume one trace means one cycle we care about.
+
+    # To stop the loop after one iteration for testing:
+    # Make generate_patch return None after the first call.
+    async def generate_patch_side_effect(*args, **kwargs):
+        if mock_generate_patch.call_count == 1: # Corrected: use mock_generate_patch.call_count
+            fut = asyncio.Future()
+            fut.set_result(test_patch)
+            return fut
+        fut_none = asyncio.Future()
+        fut_none.set_result(None) # Stop loop after one successful patch cycle
+        return fut_none
+
+    mock_generate_patch.side_effect = generate_patch_side_effect
+
+    # Run the loop. It will break when generate_patch returns None.
+    # Or, more robustly, run it as a task and cancel after a short delay.
+    loop_task = asyncio.create_task(meta_loop.meta_loop())
+    # Increased sleep slightly to ensure the full loop including mocked sub-awaits can complete.
+    await asyncio.sleep(0.5) # Allow loop to run at least one full cycle
+    loop_task.cancel()
+    try:
+        await loop_task
+    except asyncio.CancelledError:
+        log.info("Meta_loop task cancelled as expected for test.")
+
+    # Assertions:
+    # - generate_patch was called
+    # - _prove_patch was called with the patch
+    # - _apply_patch was called with the patch
+    # - proofable_reward was called
+    # - Patch was logged to APPLIED_LOG in Redis
+    assert mock_generate_patch.call_count >= 1 # Should be called at least once
+    mock_prove_patch.assert_called_with(test_patch)
+    mock_apply_patch.assert_called_with(test_patch)
+    mock_proofable_reward.assert_called_with(trace_1, {}) # Assuming empty context for now
+
+    applied_log_content = fake_redis.lrange(meta_loop.APPLIED_LOG, 0, -1)
+    assert len(applied_log_content) == 1
+    logged_patch = json.loads(applied_log_content[0])
+    assert logged_patch["target"] == str(target_file_path)
+    assert logged_patch["rationale"] == "Test rationale"
+    assert logged_patch["reward"] == 1.0
+
+    # Check that the target file was actually modified by _apply_patch
+    # In a real test of _apply_patch, we'd check file content.
+    # Here, mock_apply_patch is used, so we trust it was called.
+    # If we were testing the real _apply_patch, we'd do:
+    # assert target_file_path.read_text() == test_patch["after"]
+    log.info("Test passed: meta_loop applied a good patch.")
+
+# TODO: Add test for meta_loop_rolls_back_bad_patch
+# Similar to above, but proofable_reward returns a negative value,
+# and we assert that _rollback is called and the patch is not in APPLIED_LOG.
+# Need to mock _rollback as well for that.
+
+# TODO: Add test for meta_loop_skips_unproven_patch
+# Similar, but _prove_patch returns False. Assert _apply_patch is not called.


### PR DESCRIPTION
I've implemented the core structure and functionality for the Darwin Gödel Machine (DGM) self-improvement meta-loop as defined in `dgm_kernel/meta_loop.py`.

Key changes include:
- Creation of `dgm_kernel/meta_loop.py`.
- Implementation of `fetch_recent_traces` for retrieving traces from Redis, including error handling for JSON decoding and Redis connectivity.
- Placeholder implementation for `generate_patch` which will later house the logic for LLM/search-based code patch generation. It currently returns a predefined patch targeting `osiris_policy/strategy.py`.
- Placeholder implementation for `_prove_patch` to simulate patch verification by an external process.
- Review and adoption of the provided `_apply_patch` and `_rollback` functions for applying/reverting patches to the filesystem and reloading modules, with enhancements for directory creation and module loading robustness.
- Integration of these components into the main `meta_loop`, which orchestrates trace fetching, patch generation, proving, application, reward evaluation (using `proofable_reward`), and rollback logic.
- Addition of initial unit tests using `fakeredis` and `unittest.mock` for `fetch_recent_traces` and the main `meta_loop` flow, covering successful patch application and Redis interactions.

This provides the foundational asynchronous loop for the DGM's self-improving patch mechanism. Further work will involve replacing placeholders with actual LLM/verifier interactions and expanding test coverage.