### PR TITLE
I've made the following changes to address the MuseTalk CI smoke test…

### DIFF
--- a/tests/smoke_test_musetalk.sh
+++ b/tests/smoke_test_musetalk.sh
@@ -3,18 +3,6 @@
 # Exit immediately if a command exits with a non-zero status.
 set -e
 
-# Create a unique temporary directory
-TMP_DIR=$(mktemp -d -t musetalk_smoke_test.XXXXXX)
-
-# Function to clean up the temporary directory on script exit
-cleanup() {
-  echo "Cleaning up temporary directory: $TMP_DIR"
-  rm -rf "$TMP_DIR"
-}
-
-# Register the cleanup function to be called on EXIT signal
-trap cleanup EXIT
-
 # Check if AVATAR environment variable is set and points to an existing file
 if [ -z "$AVATAR" ]; then
   echo "Error: AVATAR environment variable is not set."
@@ -27,13 +15,16 @@ else
 fi
 
 # Define the destination path for the copied avatar
-DEST_AVATAR_PATH="$TMP_DIR/copied_avatar.png"
+DEST_AVATAR_PATH="/tmp_pipe_smoke_test/avatar_input.png"
+
+# Create the destination directory
+mkdir -p /tmp_pipe_smoke_test
 
 # Perform the copy operation
 echo "Copying '$AVATAR' to '$DEST_AVATAR_PATH'..."
 cp "$AVATAR" "$DEST_AVATAR_PATH"
 
-# Verify that the copied file exists in the temporary directory
+# Verify that the copied file exists in the destination directory
 if [ -f "$DEST_AVATAR_PATH" ]; then
   echo "Successfully copied avatar to '$DEST_AVATAR_PATH'."
 else


### PR DESCRIPTION
… path:

- Updated `DEST_AVATAR_PATH` to `/tmp_pipe_smoke_test/avatar_input.png`.
- Removed the logic for creating and cleaning up temporary directories.
- Added a command to create `/tmp_pipe_smoke_test` if it doesn't already exist.