### PR TITLE
Okay, I've added the skeleton for `nightly_trainer/driver.py` and a c…

### DIFF
--- a/nightly_trainer/README.md
+++ b/nightly_trainer/README.md
@@ -1,0 +1,3 @@
+# Nightly Trainer
+
+This directory contains scripts and configurations for nightly model training.

--- a/nightly_trainer/driver.py
+++ b/nightly_trainer/driver.py
@@ -1,0 +1,27 @@
+import argparse
+import logging
+
+# Configure basic logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+def main():
+    """
+    Parses command-line arguments and executes tasks based on the --task-set argument.
+    """
+    parser = argparse.ArgumentParser(description="Nightly trainer driver script.")
+    parser.add_argument(
+        "--task-set",
+        type=str,
+        required=True,
+        help="The set of tasks to run (e.g., 'marketforge')."
+    )
+
+    args = parser.parse_args()
+
+    if args.task_set == "marketforge":
+        logging.info("trainer loop stub")
+    else:
+        logging.warning(f"Unknown task set: {args.task_set}")
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_nightly_trainer.py
+++ b/tests/test_nightly_trainer.py
@@ -1,0 +1,52 @@
+import subprocess
+import os
+import sys
+
+def test_driver_marketforge_task_set():
+    """
+    Tests that running driver.py with --task-set marketforge logs "trainer loop stub".
+    """
+    # Construct the path to the driver.py script relative to this test file.
+    # This assumes the tests directory is at the root of the project,
+    # and nightly_trainer is also at the root.
+    project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    driver_script_path = os.path.join(project_root, "nightly_trainer", "driver.py")
+
+    # Ensure the script path is correct and exists
+    if not os.path.exists(driver_script_path):
+        raise FileNotFoundError(f"Could not find driver script at {driver_script_path}")
+
+    try:
+        # Run the script using the same Python interpreter that's running the tests
+        process = subprocess.run(
+            [sys.executable, driver_script_path, "--task-set", "marketforge"],
+            capture_output=True,
+            text=True,
+            check=False,  # Check manually to provide better error message
+            timeout=10 # Add a timeout to prevent tests from hanging
+        )
+
+        # Combine stdout and stderr for checking the log message
+        output = process.stdout + process.stderr
+
+        if process.returncode != 0:
+            print(f"Error running script. Exit code: {process.returncode}")
+            print(f"Stdout:\n{process.stdout}")
+            print(f"Stderr:\n{process.stderr}")
+
+        assert process.returncode == 0, f"Script exited with {process.returncode}, output: {output}"
+        assert "trainer loop stub" in output, f"'trainer loop stub' not found in output: {output}"
+
+    except FileNotFoundError:
+        # This might happen if sys.executable or driver_script_path is incorrect
+        assert False, f"Could not find Python interpreter or script. Searched for script at {driver_script_path}"
+    except subprocess.TimeoutExpired:
+        assert False, "Running the driver script timed out."
+    except Exception as e:
+        assert False, f"An unexpected error occurred: {e}"
+
+if __name__ == "__main__":
+    # This allows running the test directly e.g., python tests/test_nightly_trainer.py
+    # For more comprehensive test runs, a test runner like pytest is recommended.
+    test_driver_marketforge_task_set()
+    print("Test passed.")


### PR DESCRIPTION
…orresponding test for you.

Here's a summary of what I did:
- I created the `nightly_trainer` directory.
- I added `nightly_trainer/driver.py`. This script includes basic command-line argument parsing.
    - It can accept a `--task-set` argument.
    - If you provide `--task-set marketforge`, it will log "trainer loop stub".
- I also added `tests/test_nightly_trainer.py` to check the driver script.
    - This test runs the driver with `--task-set marketforge`.
    - It then makes sure the script outputs "trainer loop stub" as expected and exits without errors.

This new setup will make it easier to add more nightly training tasks in the future and ensures the basic command-line interface is working correctly.