### PR TITLE
docs: fix missing space in arch_v2 description

### DIFF
--- a/docs/arch_v2_description.txt
+++ b/docs/arch_v2_description.txt
@@ -118,7 +118,7 @@ This document describes the components and interactions of the v2 architecture, 
 *   Arrows should be labeled with the type of interaction (HTTP, Event name, Data type like "Run Log" or "Feedback Data").
 *   Use dotted lines or a different color for conceptual flows like the Nightly QLoRA process if it's not a direct, real-time interaction with the core request-response cycle.
 
-This description should provide a solid foundation for creating the `arch_v2.drawio` diagram.Okay, I've created the architecture description file `docs/arch_v2_description.txt`.
+This description should provide a solid foundation for creating the `arch_v2.drawio` diagram. Okay, I've created the architecture description file `docs/arch_v2_description.txt`.
 
 Next, I'll update `README.md`. I need to:
 1.  Add the placeholder for the new architecture diagram and a link to the description file.


### PR DESCRIPTION
## Summary
- correct a missing space between sentences in `arch_v2_description.txt`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fd8d09524832f84e07b9e4b17bfa4