### PR TITLE
Fix invalid model_id message

### DIFF
--- a/server.py
+++ b/server.py
@@ -437,7 +437,7 @@ async def generate_unified(req: UnifiedPromptRequest):
         return {"generated_text": txt}
 
     return {
-        "error": "Invalid model_id. Use 'hermes' or 'phi3'.",
+        "error": "Invalid model_id specified. Choose 'hermes' or 'phi3'.",
         "specified_model_id": req.model_id,
     }
 


### PR DESCRIPTION
## Summary
- clarify error message on invalid `model_id`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: no module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_683fd8d86534832fbc2f3f3b449f7707