### PR TITLE
Fix /generate invalid model id response

### DIFF
--- a/server.py
+++ b/server.py
@@ -436,10 +436,10 @@ async def generate_unified(req: UnifiedPromptRequest):
             return {"error": txt}
         return {"generated_text": txt}
 
-    return {
-        "error": "Invalid model_id specified. Choose 'hermes' or 'phi3'.",
-        "specified_model_id": req.model_id,
-    }
+    raise HTTPException(
+        status_code=422,
+        detail="Invalid model_id specified. Choose 'hermes' or 'phi3'.",
+    )
 
 
 @app.post("/generate/hermes/", tags=["hermes"])


### PR DESCRIPTION
## Summary
- raise `HTTPException` for bad model ids in `/generate/`
- update tests for 422 error message

## Testing
- `pytest tests/test_server.py -k generate_invalid_model_id -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_683fe0445d68832f9129a3957ad94d3f