### PR TITLE
Enable OTEL traces from sidecar

### DIFF
--- a/.github/workflows/e2e-orchestrator.yaml
+++ b/.github/workflows/e2e-orchestrator.yaml
@@ -25,6 +25,10 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      otel-collector:
+        image: otel/opentelemetry-collector:0.92.0
+        ports:
+          - 4318:4318
 
     steps:
       - name: Checkout code
@@ -63,6 +67,11 @@ jobs:
           push_image: false
           # build_args: '' # If HF_TOKEN is an ARG in Dockerfile, it might be picked from env if set
           # For explicit secret build args, reusable workflow might need updates or use build-args with secrets.
+
+      - name: Configure OTEL environment
+        run: |
+          echo "OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318" >> .env
+          echo "OTEL_SERVICE_NAME=llm-sidecar" >> .env
 
       - name: Run LLM Sidecar Docker Container
         run: |
@@ -111,6 +120,11 @@ jobs:
         # env:
         #   REDIS_URL: redis://localhost:6379/0 # If orchestrator needs to connect to Redis directly
 
+      - name: Verify OTEL traces sent
+        run: |
+          docker logs ${{ job.services.otel-collector.id }} > otel-collector.log
+          grep "/v1/traces" otel-collector.log
+
       - name: Dump service logs on failure
         if: failure()
         run: |
@@ -130,6 +144,7 @@ jobs:
           path: |
             llm-sidecar-logs.txt
             vram-watchdog-logs.txt
+            otel-collector.log
           if-no-files-found: ignore
           retention-days: 7
 

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -20,13 +20,16 @@ services:
       # Adjust the source path if your server.py is located elsewhere relative to the compose file
       - ../server.py:/app/server.py
       # It's good practice to also ensure the model directory is correctly handled.
-      # If the model is downloaded during the build (as in the Dockerfile), 
+      # If the model is downloaded during the build (as in the Dockerfile),
       # it will be part of the image. If you were to download it at runtime or
       # want to persist it outside the container, a volume mount here would be necessary.
       # For now, relying on the Dockerfile's RUN git clone ... is sufficient.
       # Example for persisting model outside container (optional, and adjust path):
       # - ./hermes-model-data:/app/hermes-model
       - ./lancedb_data:/app/lancedb_data
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT}
+      - OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-llm-sidecar}
     # Adding a healthcheck can be useful for production, but is optional here
     # healthcheck:
     #   test: ["CMD", "curl", "-f", "http://localhost:8000/health"]

--- a/docs/ARCH.md
+++ b/docs/ARCH.md
@@ -132,4 +132,5 @@ First, let's read the current `README.md` to see if there's an existing architec
 | Key | Path | Default | Description |
 |-----|------|---------|-------------|
 | `otel.enabled` | `helm/osiris/values.yaml` | `false` | Turns on OpenTelemetry instrumentation for all pods. |
+| `OTEL_SERVICE_NAME` | Derived | `llm-sidecar` when `otel.enabled` is true | Sets the service name for traces. |
 | `musetalk.useGpu` | `helm/osiris/values.yaml` | `true` | Schedules MuseTalk container on a GPU node via `nvidia.com/gpu.present=true`. |

--- a/helm/osiris/templates/llm-sidecar-deployment.yaml
+++ b/helm/osiris/templates/llm-sidecar-deployment.yaml
@@ -50,6 +50,11 @@ spec:
           - configMapRef:
               name: {{ include "osiris.fullname" . }}-llm-sidecar-config
           {{- end }}
+          {{- if .Values.otel.enabled }}
+          env:
+            - name: OTEL_SERVICE_NAME
+              value: llm-sidecar
+          {{- end }}
       # GPU Node Selector: Only apply if .Values.llmSidecar.nodeSelector is not empty
       {{- with .Values.llmSidecar.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
## Summary
- send OTEL traces from the sidecar by setting `OTEL_SERVICE_NAME`
- launch an otel collector in the orchestrator smoke test
- check collector logs for `/v1/traces`
- document the new trace env var
- expose OTEL env vars through docker compose

## Testing
- `pip install pytest`
- `pytest -q` *(fails: Failed to import optimum.onnxruntime.modeling_decoder because of missing module 'onnx')*

------
https://chatgpt.com/codex/tasks/task_e_683fe12781d4832fb6d151beb25938f4