### PR TITLE
Add Phi-3 adapter swap smoke test

### DIFF
--- a/.github/workflows/e2e-adapter-swap.yaml
+++ b/.github/workflows/e2e-adapter-swap.yaml
@@ -1,0 +1,97 @@
+name: E2E Adapter Swap Smoke Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      TORCH_VERSION: "2.2.2+cu121"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-torch-${{ env.TORCH_VERSION }}
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/buildx
+          key: ${{ runner.os }}-buildx-${{ hashFiles('docker/Dockerfile') }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Osiris Setup
+        uses: ./.github/actions/osiris-setup
+        with:
+          python-version: '3.11'
+          install-requirements: 'false'
+          system-packages: 'docker-compose'
+
+      - name: Build llm-sidecar Docker image
+        uses: ./.github/actions/docker_build
+        with:
+          image_name: 'llm-sidecar'
+          dockerfile: 'docker/Dockerfile'
+          context: 'docker'
+          push_image: false
+
+      - name: Start llm-sidecar
+        run: |
+          docker compose -f docker/compose.yaml up -d llm-sidecar
+
+      - name: Wait for llm-sidecar service
+        run: |
+          echo "Waiting for llm-sidecar service to be running..."
+          MAX_RETRIES=18
+          RETRY_COUNT=0
+          SERVICE_NAME="llm-sidecar"
+          until [ $RETRY_COUNT -ge $MAX_RETRIES ]; do
+            RUNNING_SERVICES=$(docker compose -f docker/compose.yaml ps --services --filter "status=running")
+            if echo "${RUNNING_SERVICES}" | grep -Eq "^${SERVICE_NAME}$"; then
+              echo "$SERVICE_NAME service is running."
+              break
+            fi
+            RETRY_COUNT=$((RETRY_COUNT + 1))
+            FORMATTED_RUNNING_SERVICES=$(echo "${RUNNING_SERVICES}" | tr '\n' ' ' | sed 's/ $//')
+            echo "Waiting for $SERVICE_NAME... Attempt $RETRY_COUNT/$MAX_RETRIES. Currently running: [${FORMATTED_RUNNING_SERVICES:-none}]"
+            sleep 10
+          done
+          if [ $RETRY_COUNT -ge $MAX_RETRIES ]; then
+            echo "Service $SERVICE_NAME did not start in time."
+            exit 1
+          fi
+
+      - name: Run adapter swap smoke test
+        run: bash tests/smoke_test_adapter_swap.sh
+
+      - name: Dump service logs on failure
+        if: failure()
+        run: |
+          docker ps -a
+          echo "---- llm-sidecar logs ----"
+          docker compose -f docker/compose.yaml logs llm-sidecar > llm-sidecar-logs.txt || echo "llm-sidecar logs not available" > llm-sidecar-logs.txt
+
+      - name: Upload service logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: service-logs-e2e-adapter-swap
+          path: llm-sidecar-logs.txt
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Stop Docker container
+        if: always()
+        run: |
+          docker compose -f docker/compose.yaml down

--- a/server.py
+++ b/server.py
@@ -599,7 +599,19 @@ async def submit_phi3_feedback(feedback: FeedbackItem): # Renamed from submit_fe
         logger.error(f"Error submitting feedback or publishing event for {feedback.transaction_id}: {e}")
         # Decide if you want to raise HTTPException for client, or just log
         # For now, let's return an error message to the client as well.
+
         raise HTTPException(status_code=500, detail=f"Failed to process feedback: {e}")
+
+
+@app.post("/adapters/swap", tags=["meta"])
+async def swap_phi3_adapter():
+    """Reload the Phi-3 model and adapter from disk."""
+    try:
+        load_phi3_model()
+        return {"status": "ok", "phi3_adapter_date": phi3_adapter_date}
+    except Exception as e:
+        logger.error(f"Error swapping Phi-3 adapter: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to swap adapter: {e}")
 
 
 @app.get("/health", tags=["meta"])

--- a/tests/smoke_test_adapter_swap.sh
+++ b/tests/smoke_test_adapter_swap.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+DATE=$(date +%Y%m%d)
+
+echo "Pulling test adapter image..."
+docker pull ghcr.io/osiris/test-adapter:latest
+
+CID=$(docker create ghcr.io/osiris/test-adapter:latest)
+mkdir -p ./test-adapter
+
+echo "Copying adapter from container..."
+docker cp "${CID}:/adapter" ./test-adapter
+
+docker rm "$CID"
+
+SIDECAR_ID=$(docker compose -f docker/compose.yaml ps -q llm-sidecar)
+
+echo "Copying adapter into llm-sidecar container..."
+docker cp ./test-adapter "${SIDECAR_ID}:/app/models/phi3/adapters/${DATE}"
+
+curl -s -X POST http://localhost:8000/adapters/swap
+sleep 5
+
+EXPECTED=$(echo "$DATE" | sed 's/\(....\)\(..\)\(..\)/\1-\2-\3/')
+HEALTH=$(curl -s http://localhost:8000/health)
+
+echo "$HEALTH"
+ADAPTER_DATE=$(echo "$HEALTH" | jq -r '.phi3_adapter_date')
+
+if [ "$ADAPTER_DATE" != "$EXPECTED" ]; then
+  echo "Adapter date mismatch: expected $EXPECTED got $ADAPTER_DATE"
+  exit 1
+fi
+
+echo "Adapter swap smoke test passed."


### PR DESCRIPTION
## Summary
- implement `/adapters/swap` endpoint to reload Phi-3 adapter
- add E2E workflow that verifies hot-swapping the adapter
- script to pull test adapter image and check health endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_683fe381dea0832f9db5c71661f9dde3