### PR TITLE
Add canary stage for Helm

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,18 @@ azrPlanner:
   # ... other configuration ...
 ```
 
+### Canary Deployment
+
+Use `helm/osiris/values-canary.yaml` to deploy a canary release. This file
+configures a single replica with 10% of incoming traffic routed to the canary
+namespace and enables full OpenTelemetry tracing.
+
+```bash
+helm upgrade --install osiris-canary helm/osiris \
+  -f helm/osiris/values-canary.yaml \
+  --namespace osiris-canary --create-namespace
+```
+
 ### Environment Variables (AZR Planner)
 
 *   *(No specific environment variables are currently defined or used by the stub service beyond standard Uvicorn/FastAPI configurations.)*

--- a/helm/osiris/values-canary.yaml
+++ b/helm/osiris/values-canary.yaml
@@ -1,0 +1,8 @@
+replicaCount: 1
+
+trafficWeight: 10
+
+otel:
+  enabled: true
+  trace:
+    sample: 1.0


### PR DESCRIPTION
## Summary
- add values-canary.yaml for Kubernetes canary deployments
- document how to deploy the canary chart in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `yamllint --strict .`
- `actionlint` *(failed to download)*

------
https://chatgpt.com/codex/tasks/task_e_683fe374c224832f9e80c6c7c62bbfab