### PR TITLE
Add editable install to docker_build action

### DIFF
--- a/.github/actions/docker_build/action.yml
+++ b/.github/actions/docker_build/action.yml
@@ -105,3 +105,9 @@ runs:
       if: always() && inputs.push_image == true && inputs.registry_user != '' && inputs.registry_password != ''
       shell: bash
       run: docker logout
+
+    - name: Install repo (editable)
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -e .


### PR DESCRIPTION
## Summary
- install repo in editable mode for CI composite action

## Testing
- `pytest -k test_harvest.py -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_683fe5ef5fbc832f8fcb15a1a76c1f56