### PR TITLE
Add CI guard for sys.path.append

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+
+
       - name: Install linters
         run: |
           sudo apt-get update
@@ -138,6 +140,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Guard against sys.path.append usage
+        run: ! grep -R "sys.path.append" tests | grep -v vendor
 
       - name: Cache pip dependencies
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- ensure tests don't call `sys.path.append`

## Testing
- `pytest tests/test_harvest.py` *(fails: LanceDB and pandas missing)*

------
https://chatgpt.com/codex/tasks/task_e_683fe61e11bc832f91e2fb421843860f