### PR TITLE
Add minimal package metadata

### DIFF
--- a/osiris/__init__.py
+++ b/osiris/__init__.py
@@ -1,0 +1,1 @@
+"""osiris package root."""

--- a/osiris/llm_sidecar/__init__.py
+++ b/osiris/llm_sidecar/__init__.py
@@ -1,0 +1,22 @@
+"""Wrapper package exposing project modules under the ``osiris.llm_sidecar`` namespace."""
+
+import importlib
+import sys
+import types
+
+_base = importlib.import_module("llm_sidecar")
+__all__ = getattr(_base, "__all__", dir(_base))
+__path__ = getattr(_base, "__path__", [])
+
+def __getattr__(name):
+    return getattr(_base, name)
+
+# Lazily expose ``server`` module to avoid heavy imports during package load
+_server_module = types.ModuleType(__name__ + ".server")
+
+def _server_getattr(name):
+    server_mod = importlib.import_module("server")
+    return getattr(server_mod, name)
+
+_server_module.__getattr__ = _server_getattr
+sys.modules[__name__ + ".server"] = _server_module

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "osiris"
+version = "0.0.0"
+
+[tool.setuptools.packages.find]
+include = ["osiris*", "llm_sidecar*", "osiris_policy*"]


### PR DESCRIPTION
## Summary
- add `pyproject.toml` configuring setuptools
- expose modules under `osiris.llm_sidecar` to allow imports without heavy dependencies

## Testing
- `python -m pip install -e .`
- `python -c "import osiris.llm_sidecar.server"`

------
https://chatgpt.com/codex/tasks/task_e_683fe5e89604832fa24aeb1f5858fd99