### PR TITLE
Add requirements-tests file

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,0 +1,1 @@
+httpx>=0.27 # FastAPI test client


### PR DESCRIPTION
## Summary
- include a requirements-tests.txt for dev dependencies

## Testing
- `pip install httpx==0.27.0 fastapi==0.109.2`
- `pytest tests/test_server.py -k test_generate_invalid_model_id -q` *(fails: ModuleNotFoundError: No module named 'sentry_sdk')*

------
https://chatgpt.com/codex/tasks/task_e_683fe912d318832fb74d1fd7dd8dfd6b