### PR TITLE
Update docker_build action to install test deps

### DIFF
--- a/.github/actions/docker_build/action.yml
+++ b/.github/actions/docker_build/action.yml
@@ -59,6 +59,15 @@ runs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Install package + test deps
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -e .
+        if [ -f requirements-ci.txt ]; then
+          python -m pip install -r requirements-ci.txt
+        fi
+
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
 


### PR DESCRIPTION
## Summary
- install editable package and test dependencies in the docker_build composite action

## Testing
- `python -m pip install -e .`
- `python -m pip install -r requirements-ci.txt` *(failed: ModuleNotFoundError: No module named 'lancedb')*
- `pytest tests/test_harvest.py::test_write_and_load_feedback` *(failed: ModuleNotFoundError: No module named 'lancedb')*

------
https://chatgpt.com/codex/tasks/task_e_683fe91fff78832fa707336a22f64121