### PR TITLE
Update docker_build composite action to install test deps

### DIFF
--- a/.github/actions/docker_build/action.yml
+++ b/.github/actions/docker_build/action.yml
@@ -59,6 +59,9 @@ runs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Install test requirements
+      run: pip install -r requirements-tests.txt
+
     - name: Install package + test deps
       shell: bash
       run: |


### PR DESCRIPTION
## Summary
- install `requirements-tests.txt` before running build steps in CI

## Testing
- `pip install -r requirements-tests.txt`
- `pip install -e .`
- `pytest -k nonexistent` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_683fec2de760832fa2af9f07b7a2a30c