### PR TITLE
Re-export server for legacy tests

### DIFF
--- a/osiris/llm_sidecar/__init__.py
+++ b/osiris/llm_sidecar/__init__.py
@@ -8,6 +8,9 @@ _base = importlib.import_module("llm_sidecar")
 __all__ = list(getattr(_base, "__all__", dir(_base)))
 __path__ = getattr(_base, "__path__", [])
 
+from .. import server  # re-export for legacy tests
+__all__ = ["server", *globals().get("__all__", [])]
+
 def __getattr__(name):
     return getattr(_base, name)
 


### PR DESCRIPTION
## Summary
- expose `server` under `osiris.llm_sidecar` for compatibility

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_683ff021bc10832f8e007f62974adabb