### PR TITLE
ci: install requirements-tests in docker_build composite action

### DIFF
--- a/.github/actions/docker_build/action.yml
+++ b/.github/actions/docker_build/action.yml
@@ -71,6 +71,9 @@ runs:
           python -m pip install -r requirements-ci.txt
         fi
 
+    - name: Install test dependencies
+      run: pip install -r requirements-tests.txt
+
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
 


### PR DESCRIPTION
## Summary
- install test dependencies in docker_build composite action

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_683ff2b6982c832fa98b1fb844404613