### PR TITLE
docs: mention requirements-tests in DEV_GUIDE

### DIFF
--- a/docs/DEV_GUIDE.md
+++ b/docs/DEV_GUIDE.md
@@ -2,7 +2,7 @@
 
 This document outlines the recommended steps for a local development setup.
 
-## Local Setup
+## Setting up a dev env
 
 1. Copy the environment template and adjust any settings:
 
@@ -16,6 +16,8 @@ This document outlines the recommended steps for a local development setup.
    ```bash
    pip install -e .
    ```
+
+- `pip install -r requirements-tests.txt` installs extras needed only for running tests.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- mention that `pip install -r requirements-tests.txt` installs test-only extras

## Testing
- `pytest -q tests/test_db_bootstrap.py` *(fails: Table 'hermes_scores' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff2c36254832f8a4d229c0affc2f7