### PR TITLE
Fix actionlint installation and test dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,13 +15,16 @@ jobs:
         uses: actions/checkout@v4
 
 
-
       - name: Install linters
         run: |
           sudo apt-get update
           sudo apt-get install -y yamllint
-          curl -sSL https://github.com/rhysd/actionlint/releases/latest/download/actionlint_linux_amd64 -o actionlint
-          sudo install -m 0755 actionlint /usr/local/bin/actionlint
+          set -eux
+          ver="$(curl -sSL https://api.github.com/repos/rhysd/actionlint/releases/latest | jq -r .tag_name)"
+          curl -sSL \
+            "https://github.com/rhysd/actionlint/releases/download/${ver}/actionlint_${ver#v}_linux_amd64.tar.gz" \
+            | tar -xz -C /usr/local/bin actionlint
+          actionlint --version
 
       - name: Run actionlint
         run: actionlint
@@ -156,6 +159,10 @@ jobs:
           python-version: '3.10'
           install-requirements: 'true'
           system-packages: '' # No extra system packages needed for this job by default
+
+      - name: Install test requirements
+        run: |
+          pip install -r requirements-tests.txt
 
       - name: Run Pytest
         run: |


### PR DESCRIPTION
## Summary
- install actionlint from the official release tarball
- install extra Python test requirements during unit tests

## Testing
- `yamllint -d .yamllint.yaml .github/workflows/ci.yaml`
- `pytest tests/test_harvest.py -q` *(fails: ModuleNotFoundError: pandas)*

------
https://chatgpt.com/codex/tasks/task_e_683ff485633c832f9f5f893a9defa5cb