### PR TITLE
Fix actionlint install in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,10 +15,13 @@ jobs:
         uses: actions/checkout@v4
 
 
-      - name: Install linters
+      - name: Install yamllint
         run: |
           sudo apt-get update
           sudo apt-get install -y yamllint
+
+      - name: Install actionlint
+        run: |
           set -eux
           ver="$(curl -sSL https://api.github.com/repos/rhysd/actionlint/releases/latest | jq -r .tag_name)"
           curl -sSL \


### PR DESCRIPTION
## Summary
- fix the lint job by installing actionlint from the official tarball

## Testing
- `pytest tests/test_harvest.py -q` *(fails: ModuleNotFoundError: No module named 'onnx')*

------
https://chatgpt.com/codex/tasks/task_e_683ff7605340832f89e68ee9d6eb0a91