### PR TITLE
Fix actionlint install path in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,8 +25,8 @@ jobs:
           set -eux
           ver="$(curl -sSL https://api.github.com/repos/rhysd/actionlint/releases/latest | jq -r .tag_name)"
           curl -sSL \
-            "https://github.com/rhysd/actionlint/releases/download/${ver}/actionlint_${ver#v}_linux_amd64.tar.gz" |
-            tar -xz -C /usr/local/bin actionlint
+            "https://github.com/rhysd/actionlint/releases/download/${ver}/actionlint_${ver#v}_linux_amd64.tar.gz" \
+            | tar -xz -C /usr/local/bin actionlint
           actionlint --version
 
       - name: Run actionlint


### PR DESCRIPTION
## Summary
- update Install actionlint step in CI workflow

## Testing
- `actionlint .github/workflows/ci.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684065be15d8832fb74fd28b7570082a