### PR TITLE
Fix CI test deps install

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,8 +163,9 @@ jobs:
           install-requirements: 'true'
           system-packages: '' # No extra system packages needed for this job by default
 
-      - name: Install test-only deps
+      - name: Install Python dependencies
         run: |
+          pip install -r requirements.txt
           pip install -r requirements-tests.txt
 
       - name: Run Pytest


### PR DESCRIPTION
## Summary
- ensure test-only deps installed along with app requirements

## Testing
- `pytest tests/test_harvest.py::test_fetch_with_limit -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684068ee6480832f9bbc347be5a390a1