### PR TITLE
fix-dockerfile-copy-paths-in-llm-sidecar-smoke-test

### DIFF
--- a/.github/workflows/nightly-fine-tune.yaml
+++ b/.github/workflows/nightly-fine-tune.yaml
@@ -53,7 +53,7 @@ jobs:
           image_name: 'llm_sidecar'
           image_tag: 'latest' # Explicitly 'latest' as in the original command
           dockerfile: 'docker/Dockerfile' # Path from repo root
-          context: '.' # Build context is the repo root
+          context: 'docker' # Build context points to docker/ for correct COPY paths
           push_image: false
           # build_args: '' # No specific build_args mentioned
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy constraints file for torch installation
-COPY constraints.txt /tmp/constraints.txt
-COPY requirements.txt /tmp/requirements.txt
+COPY ../constraints.txt /tmp/constraints.txt
+COPY ../requirements.txt /tmp/requirements.txt
 
 # Install Python dependencies from requirements.txt using constraints.txt
 RUN pip3 install --no-cache-dir -r /tmp/requirements.txt -c /tmp/constraints.txt


### PR DESCRIPTION
## Summary
- fix Dockerfile COPY paths to reference repo root files
- update nightly fine tune workflow to use `docker` build context

## Testing
- `pytest tests/test_harvest.py` *(fails: ModuleNotFoundError: No module named 'sentry_sdk')*

------
https://chatgpt.com/codex/tasks/task_e_68407abb2274832f9c3b858ac9f1203c