### PR TITLE
feat: implement prove_patch() and tests for patch safety

### DIFF
--- a/tests/dgm/test_prover.py
+++ b/tests/dgm/test_prover.py
@@ -1,0 +1,25 @@
+import pytest
+from hypothesis import given, strategies as st
+
+from dgm_kernel.prover import prove_patch
+
+@given(st.text().filter(lambda s: s.strip() == ""))
+def test_empty_diffs_invalid(empty_diff):
+    result = prove_patch(id="1", diff=empty_diff, patch_code="")
+    assert not result.is_valid
+
+@given(st.text(min_size=1).filter(lambda s: s.strip() != ""))
+def test_valid_diff_passes(code):
+    diff = "--- a/file.py\n+++ b/file.py\n@@\n-old\n+new"
+    result = prove_patch(id="1", diff=diff, patch_code=code)
+    assert result.is_valid
+
+@given(st.sampled_from([
+    "secrets/token.txt",
+    ".env",
+    "tests/unit/__snapshots__/out.snap"
+]))
+def test_forbidden_paths_fail(path):
+    diff = f"--- a/{path}\n+++ b/{path}\n@@\n-old\n+new"
+    result = prove_patch(id="1", diff=diff, patch_code="print('x')")
+    assert not result.is_valid

--- a/tests/dgm_kernel/test_prover.py
+++ b/tests/dgm_kernel/test_prover.py
@@ -2,53 +2,13 @@ import unittest
 from unittest.mock import patch, MagicMock
 import subprocess
 from pathlib import Path
-from dgm_kernel.prover import prove_patch, _get_pylint_score, VerifiedPatch
+from dgm_kernel.prover import _get_pylint_score
 
 class TestProver(unittest.TestCase):
 
     DUMMY_ID = "test_id_123"
     DUMMY_DIFF = "--- a/file.py\n+++ b/file.py\n@@ -1,1 +1,1 @@\n-old\n+new"
     DUMMY_CODE = "print('hello world')"
-
-    @patch('dgm_kernel.prover._get_pylint_score')
-    def test_prove_patch_approved_high_score(self, mock_get_pylint_score):
-        mock_get_pylint_score.return_value = 9.5
-        result = prove_patch(id=self.DUMMY_ID, diff=self.DUMMY_DIFF, patch_code=self.DUMMY_CODE)
-        self.assertEqual(result.status, "APPROVED")
-        self.assertEqual(result.score, 9.5)
-        mock_get_pylint_score.assert_called_once_with(self.DUMMY_CODE)
-
-    @patch('dgm_kernel.prover._get_pylint_score')
-    def test_prove_patch_rejected_low_score(self, mock_get_pylint_score):
-        mock_get_pylint_score.return_value = 8.5
-        result = prove_patch(id=self.DUMMY_ID, diff=self.DUMMY_DIFF, patch_code=self.DUMMY_CODE)
-        self.assertEqual(result.status, "REJECTED")
-        self.assertEqual(result.score, 8.5)
-        mock_get_pylint_score.assert_called_once_with(self.DUMMY_CODE)
-
-    @patch('dgm_kernel.prover._get_pylint_score')
-    def test_prove_patch_rejected_exact_threshold_failure(self, mock_get_pylint_score):
-        mock_get_pylint_score.return_value = 8.99
-        result = prove_patch(id=self.DUMMY_ID, diff=self.DUMMY_DIFF, patch_code=self.DUMMY_CODE)
-        self.assertEqual(result.status, "REJECTED")
-        self.assertEqual(result.score, 8.99)
-        mock_get_pylint_score.assert_called_once_with(self.DUMMY_CODE)
-
-    @patch('dgm_kernel.prover._get_pylint_score')
-    def test_prove_patch_approved_exact_threshold_pass(self, mock_get_pylint_score):
-        mock_get_pylint_score.return_value = 9.0
-        result = prove_patch(id=self.DUMMY_ID, diff=self.DUMMY_DIFF, patch_code=self.DUMMY_CODE)
-        self.assertEqual(result.status, "APPROVED")
-        self.assertEqual(result.score, 9.0)
-        mock_get_pylint_score.assert_called_once_with(self.DUMMY_CODE)
-
-    @patch('dgm_kernel.prover._get_pylint_score')
-    def test_prove_patch_pylint_failure_returns_low_score_rejected(self, mock_get_pylint_score):
-        mock_get_pylint_score.return_value = 0.0
-        result = prove_patch(id=self.DUMMY_ID, diff=self.DUMMY_DIFF, patch_code=self.DUMMY_CODE)
-        self.assertEqual(result.status, "REJECTED")
-        self.assertEqual(result.score, 0.0)
-        mock_get_pylint_score.assert_called_once_with(self.DUMMY_CODE)
 
     @patch('dgm_kernel.prover.tempfile.NamedTemporaryFile')
     @patch('dgm_kernel.prover.subprocess.run')


### PR DESCRIPTION
## Summary
- rewrite `prove_patch` to check patch validity and forbid edits to secrets and snapshots
- adjust pylint score tests to only cover `_get_pylint_score`
- add hypothesis-based tests for patch verification logic

## Testing
- `pytest tests/dgm/test_prover.py tests/dgm_kernel/test_prover.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68407f36acb4832fbb208280440aca28