### PR TITLE
chore: add branch protection setup script

### DIFF
--- a/docs/DEV_GUIDE.md
+++ b/docs/DEV_GUIDE.md
@@ -23,3 +23,9 @@ This document outlines the recommended steps for a local development setup.
 
 pip install -r requirements-tests.txt before running pytest.
 
+
+## Branch protection
+
+Run `scripts/ci/setup_branch_protection.sh` once to enable the required status checks on the `main` branch. The script uses the GitHub CLI and needs an authenticated session with permission to edit repository settings.
+
+After running it, `gh api repos/:owner/:repo/branches/main/protection` should list the four checks.

--- a/scripts/ci/setup_branch_protection.sh
+++ b/scripts/ci/setup_branch_protection.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Configure branch protection for the main branch using the GitHub API.
+# Requires the GitHub CLI (gh) to be authenticated with repo admin permissions.
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY:-$(git config --get remote.origin.url | sed -E 's#.*github.com[:/]([^/]+/[^.]+)(\.git)?#\1#')}"
+BRANCH="main"
+
+read -r -d '' PAYLOAD <<'JSON'
+{
+  "required_status_checks": {
+    "strict": true,
+    "checks": [
+      {"context": "CI"},
+      {"context": "LLM Sidecar Smoke Test"},
+      {"context": "E2E Adapter Swap"},
+      {"context": "E2E Orchestrator Smoke Test"}
+    ]
+  },
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true
+  },
+  "required_linear_history": true,
+  "enforce_admins": false
+}
+JSON
+
+echo "Setting branch protection on ${REPO}:${BRANCH}..."
+
+gh api \
+    --method PATCH \
+    repos/${REPO}/branches/${BRANCH}/protection \
+    --input - <<<"${PAYLOAD}"
+
+echo "Branch protection updated."


### PR DESCRIPTION
## Summary
- script for GitHub branch protection checks
- document how to use the script in dev guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_6840855e2ba4832f84e4afb84392b9df