### PR TITLE
Add observability smoke test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,36 @@ jobs:
       - name: Run pre-commit
         run: pre-commit run --all-files
 
+  obs-smoke:
+    if: github.event_name == 'pull_request'
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Osiris Setup
+        uses: ./.github/actions/osiris-setup
+        with:
+          install-requirements: 'false'
+          system-packages: 'docker-compose curl'
+
+      - name: Copy .env template
+        run: cp .env.template .env
+
+      - name: Start sidecar
+        run: docker compose -f docker/compose.yaml up -d llm-sidecar
+
+      - name: Check metrics endpoint
+        run: |
+          sleep 5
+          set -o pipefail
+          curl -sf http://localhost:8000/metrics | grep 'vram_usage_bytes'
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f docker/compose.yaml down
+
   build-and-test-llm-sidecar:
     needs: lint
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Open‑source trading stack with local LLM agents.
 
 [![Build][ci-badge]][ci]
+![Observability](https://github.com/${{github.repository}}/actions/workflows/ci.yaml/badge.svg?branch=main&label=obs)
 [![License][license-badge]](LICENSE)
 [![Python][python-badge]](pyproject.toml)
 


### PR DESCRIPTION
## Summary
- extend CI workflow with `obs-smoke` job to curl sidecar metrics
- show new Observability badge in README

## Testing
- `pre-commit run --files .github/workflows/ci.yaml README.md`
- `yamllint .github/workflows/ci.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68408db922a4832fba98ea4060325f26