### PR TITLE
Add grafana configmaps

### DIFF
--- a/helm/osiris/Chart.yaml
+++ b/helm/osiris/Chart.yaml
@@ -12,7 +12,13 @@ version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: "1.0.0"
+appVersion: "1.1.0"
+
+dependencies:
+  - name: grafana
+    version: 9.3.0
+    repository: https://charts.bitnami.com/bitnami
+    condition: observability.grafana.enabled
 
 keywords:
   - osiris

--- a/helm/osiris/templates/grafana-dashboard-core.yaml
+++ b/helm/osiris/templates/grafana-dashboard-core.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.observability.grafana.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "osiris.fullname" . }}-grafana-dashboard-core
+  labels:
+    {{- include "osiris.labels" . | nindent 4 }}
+    app.kubernetes.io/component: grafana
+  annotations:
+    grafana_dashboard: "1"
+data:
+  core.json: |-
+    {
+      "title": "Osiris Core Metrics",
+      "uid": "osiris-core",
+      "schemaVersion": 37,
+      "version": 1,
+      "panels": [
+        {
+          "type": "timeseries",
+          "title": "CPU Usage",
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "targets": [{"expr": "avg(rate(container_cpu_usage_seconds_total[5m]))", "refId": "A"}],
+          "gridPos": {"h": 6, "w": 12, "x": 0, "y": 0}
+        },
+        {
+          "type": "timeseries",
+          "title": "Memory Usage",
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "targets": [{"expr": "avg(container_memory_usage_bytes)", "refId": "A"}],
+          "gridPos": {"h": 6, "w": 12, "x": 12, "y": 0}
+        },
+        {
+          "type": "timeseries",
+          "title": "GPU VRAM Usage",
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "targets": [{"expr": "dcgm_fb_used_bytes / dcgm_fb_total_bytes * 100", "refId": "A"}],
+          "gridPos": {"h": 6, "w": 12, "x": 0, "y": 6}
+        },
+        {
+          "type": "timeseries",
+          "title": "Inference Latency (p95)",
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "targets": [{"expr": "histogram_quantile(0.95, sum(rate(inference_latency_seconds_bucket[5m])) by (le))", "refId": "A"}],
+          "gridPos": {"h": 6, "w": 12, "x": 12, "y": 6}
+        }
+      ]
+    }
+{{- end }}

--- a/helm/osiris/templates/grafana-ds.yaml
+++ b/helm/osiris/templates/grafana-ds.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.observability.grafana.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "osiris.fullname" . }}-grafana-datasource
+  labels:
+    {{- include "osiris.labels" . | nindent 4 }}
+    app.kubernetes.io/component: grafana
+  annotations:
+    grafana_datasource: "1"
+data:
+  datasources.yaml: |-
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        access: proxy
+        url: {{ .Values.observability.grafana.prometheus.url }}
+        isDefault: true
+{{- end }}

--- a/helm/osiris/values.yaml
+++ b/helm/osiris/values.yaml
@@ -157,6 +157,12 @@ musetalk:
 prometheus:
   rules:
     create: true # Set to true to deploy the PrometheusRule custom resource
+observability:
+  grafana:
+    enabled: false
+    prometheus:
+      url: http://prometheus-server
+
 
 # Avatar specific values
 avatar:


### PR DESCRIPTION
## Summary
- ship Grafana templates and wire them up in values
- bump chart appVersion and add bitnami Grafana dependency

## Testing
- `ruff check .` *(fails: required version 0.4.4 not installed)*
- `black --check .` *(fails: required version 24.4.2 not installed)*
- `pytest -q` *(fails: missing hypothesis, fakeredis, redis, httpx, lancedb, requests)*
- `helm template helm/osiris | grep -A2 'datasources.yaml'` *(fails: helm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68408da61e80832f808fc2a39936a682