### PR TITLE
Add Prometheus metrics endpoint

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -30,6 +30,7 @@ services:
     environment:
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT}
       - OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-llm-sidecar}
+      - ENABLE_METRICS=true
     # Adding a healthcheck can be useful for production, but is optional here
     # healthcheck:
     #   test: ["CMD", "curl", "-f", "http://localhost:8000/health"]

--- a/osiris/server.py
+++ b/osiris/server.py
@@ -21,6 +21,7 @@ import torch
 from fastapi import FastAPI, HTTPException, Response, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
+from prometheus_fastapi_instrumentator import Instrumentator
 from common.otel_init import init_otel
 
 from llm_sidecar.loader import (
@@ -106,6 +107,8 @@ class ScoreRequest(BaseModel):
 # FastAPI initialisation
 # ---------------------------------------------------------------------
 app = FastAPI()
+if os.getenv("ENABLE_METRICS", "false").lower() == "true":
+    Instrumentator().instrument(app).expose(app)
 init_otel(app)  # Initialize OpenTelemetry with the FastAPI app instance
 event_bus = EventBus(redis_url="redis://localhost:6379/0")  # Global EventBus instance
 logger = logging.getLogger(__name__)  # For event handler logging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "osiris"
 version = "0.0.0"
+dependencies = [
+    "prometheus-fastapi-instrumentator>=6.1",
+]
 
 [tool.setuptools.packages.find]
 include = ["osiris*", "llm_sidecar*", "osiris_policy*"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ pylint>=2.17.0,<3.0
 opentelemetry-instrumentation-fastapi
 opentelemetry-instrumentation-logging
 opentelemetry-exporter-otlp-proto-http
+prometheus-fastapi-instrumentator>=6.1


### PR DESCRIPTION
## Summary
- allow Prometheus metrics when `ENABLE_METRICS=true`
- add prometheus-fastapi-instrumentator dependency
- turn on metrics for sidecar compose service

## Testing
- `pre-commit run --files requirements.txt pyproject.toml osiris/server.py docker/compose.yaml`
- `pytest tests/test_server.py::test_generate_hermes_default_model_id -q` *(fails: No module named 'onnx')*

------
https://chatgpt.com/codex/tasks/task_e_68408d90fb74832f851e07a00b3630dc