### PR TITLE
Add prometheus instrumentator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ opentelemetry-instrumentation-logging
 opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk
 opentelemetry-exporter-otlp
+prometheus-fastapi-instrumentator>=6.1


### PR DESCRIPTION
## Summary
- add prometheus-fastapi-instrumentator>=6.1 to requirements

## Testing
- `git status --short`
- `git log -1 --stat`
- `git push --force-with-lease origin codex/metrics-with-prom-endpoint` *(fails: 'origin' does not appear to be a git repository)*

------
https://chatgpt.com/codex/tasks/task_e_684090bc9d20832f9f447aa0003f9fd7