### PR TITLE
Implement tag release workflow

### DIFF
--- a/.github/actions/docker_build/action.yml
+++ b/.github/actions/docker_build/action.yml
@@ -39,6 +39,11 @@ inputs:
     required: false
     type: string
     default: ''
+  platforms:
+    description: 'Comma-separated list of target platforms for multi-arch builds (e.g., "linux/amd64,linux/arm64")'
+    required: false
+    type: string
+    default: ''
 
 outputs:
   image_digest:
@@ -75,6 +80,7 @@ runs:
       run: pip install -r requirements-tests.txt
 
     - name: Set up QEMU
+      if: inputs.platforms != ''
       uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx
@@ -107,9 +113,7 @@ runs:
         push: ${{ inputs.push_image }}
         tags: "${{ inputs.image_name }}:${{ inputs.image_tag }}"
         build-args: ${{ steps.build_args_array.outputs.args }}
-        # TORCH_VERSION should be inherited from the calling workflow's environment
-        # If multi-platform images are needed, pass a platforms input such as
-        # 'linux/amd64,linux/arm64'
+        platforms: ${{ inputs.platforms }}
         cache-from: |
           type=gha
           type=local,src=~/.cache/buildx

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,60 @@
+name: Release Docker Images
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      multi:
+        description: 'Build multi-platform images (linux/amd64, linux/arm64)'
+        required: false
+        default: 'false'
+        type: boolean
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      TAG: ${{ github.ref_name }}
+      MULTI: ${{ inputs.multi || 'false' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Determine platforms
+        id: platforms
+        run: |
+          if [ "${{ env.MULTI }}" = "true" ]; then
+            echo "PLATFORMS=linux/amd64,linux/arm64" >> "$GITHUB_OUTPUT"
+          else
+            echo "PLATFORMS=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push llm-sidecar
+        uses: ./.github/actions/docker_build
+        with:
+          image_name: ghcr.io/${{ github.repository_owner }}/llm-sidecar
+          image_tag: ${{ env.TAG }}
+          dockerfile: docker/Dockerfile
+          context: docker
+          push_image: true
+          registry_user: ${{ github.actor }}
+          registry_password: ${{ secrets.GITHUB_TOKEN }}
+          platforms: ${{ steps.platforms.outputs.PLATFORMS }}
+
+      - name: Build and push azr_planner
+        uses: ./.github/actions/docker_build
+        with:
+          image_name: ghcr.io/${{ github.repository_owner }}/azr_planner
+          image_tag: ${{ env.TAG }}
+          dockerfile: services/azr_planner/Dockerfile
+          context: .
+          push_image: true
+          registry_user: ${{ github.actor }}
+          registry_password: ${{ secrets.GITHUB_TOKEN }}
+          platforms: ${{ steps.platforms.outputs.PLATFORMS }}
+


### PR DESCRIPTION
## Summary
- add optional `platforms` input to docker_build composite action
- setup QEMU only when multi-arch platforms passed and forward the `platforms` list to buildx
- create `release.yaml` workflow triggered on version tags to build and push Docker images

## Testing
- `pre-commit run --files .github/workflows/release.yaml .github/actions/docker_build/action.yml`

------
https://chatgpt.com/codex/tasks/task_e_684097f710a4832f876a82383522a48c