### PR TITLE
feat(otel): instrument llm sidecar

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,1 +1,4 @@
 HERMES_CTX=6144
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+OTEL_SERVICE_NAME=osiris_llm_sidecar
+OTEL_TRACES_SAMPLER=parentbased_always_on

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -29,7 +29,8 @@ services:
       - ./lancedb_data:/app/lancedb_data
     environment:
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT}
-      - OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-llm-sidecar}
+      - OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-osiris_llm_sidecar}
+      - OTEL_TRACES_SAMPLER=${OTEL_TRACES_SAMPLER:-parentbased_always_on}
     # Adding a healthcheck can be useful for production, but is optional here
     # healthcheck:
     #   test: ["CMD", "curl", "-f", "http://localhost:8000/health"]

--- a/osiris/server.py
+++ b/osiris/server.py
@@ -22,6 +22,7 @@ from fastapi import FastAPI, HTTPException, Response, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from common.otel_init import init_otel
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 
 from llm_sidecar.loader import (
     load_hermes_model,
@@ -106,7 +107,9 @@ class ScoreRequest(BaseModel):
 # FastAPI initialisation
 # ---------------------------------------------------------------------
 app = FastAPI()
-init_otel(app)  # Initialize OpenTelemetry with the FastAPI app instance
+FastAPIInstrumentor().instrument_app(app)
+app._otel_instrumented = True  # Prevent double instrumentation in init_otel
+init_otel(app)  # Initialize OpenTelemetry (exporter & logging)
 event_bus = EventBus(redis_url="redis://localhost:6379/0")  # Global EventBus instance
 logger = logging.getLogger(__name__)  # For event handler logging
 


### PR DESCRIPTION
## Summary
- instrument FastAPI app with OTEL
- document OTEL env vars
- wire OTEL env vars in docker compose

## Testing
- `pre-commit run --files osiris/server.py .env.template docker/compose.yaml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sentry_sdk.integrations')*

------
https://chatgpt.com/codex/tasks/task_e_684097c6947c832f9c7283a167c01d89