### PR TITLE
Add OTEL tracing for orchestrator

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -54,6 +54,19 @@ services:
     #   retries: 3
     #   start_period: 5s
 
+  orchestrator:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    command: >
+      python -m osiris_policy.orchestrator --redis_url redis://localhost:6379/0
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT}
+      - OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-osiris_orchestrator}
+      - OTEL_TRACES_SAMPLER=${OTEL_TRACES_SAMPLER:-parentbased_always_on}
+    depends_on:
+      - llm-sidecar
+
   vram-watchdog:
     image: docker:latest # Using docker:latest which includes Docker CLI
     volumes:


### PR DESCRIPTION
## Summary
- wire up OpenTelemetry tracer in `osiris_policy.orchestrator`
- wrap LangGraph invocation with a span
- add orchestrator service with OTEL env vars to docker compose

## Testing
- `pytest -k orchestrator -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_684097d3b548832f841c6d75de5b6249