### PR TITLE
Add OTEL trace tests and docs pipeline

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,26 @@
+name: Build and Deploy Docs
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: pip install -r requirements-docs.txt
+      - name: Generate OpenAPI schema
+        run: make openapi
+      - name: Build site
+        run: mkdocs build -d site
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: site

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for LLM Sidecar
 
-.PHONY: rebuild logs dev-shell
+.PHONY: rebuild logs dev-shell openapi
 
 # Default service for logs if not specified
 SVC ?= llm-sidecar
@@ -13,6 +13,9 @@ logs:
 
 dev-shell:
 	dotenv -f .env -- poetry shell
+
+openapi:
+	PYTHONPATH=. python scripts/generate_openapi.py
 
 # Example usage:
 # make rebuild

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,507 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "FastAPI",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/score/hermes/": {
+      "post": {
+        "tags": [
+          "scoring"
+        ],
+        "summary": "Score Proposal With Hermes Endpoint",
+        "operationId": "score_proposal_with_hermes_endpoint_score_hermes__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScoreRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/generate/": {
+      "post": {
+        "tags": [
+          "unified"
+        ],
+        "summary": "Generate Unified",
+        "operationId": "generate_unified_generate__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UnifiedPromptRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/generate/hermes/": {
+      "post": {
+        "tags": [
+          "hermes"
+        ],
+        "summary": "Generate Hermes",
+        "operationId": "generate_hermes_generate_hermes__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PromptRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/generate/phi3/": {
+      "post": {
+        "tags": [
+          "phi3"
+        ],
+        "summary": "Generate Phi3",
+        "operationId": "generate_phi3_generate_phi3__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PromptRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/propose_trade_adjustments/": {
+      "post": {
+        "tags": [
+          "strategy"
+        ],
+        "summary": "Propose Trade",
+        "operationId": "propose_trade_propose_trade_adjustments__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PromptRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/stream/audio": {
+      "get": {
+        "tags": [
+          "tts",
+          "streaming"
+        ],
+        "summary": "Stream Audio",
+        "description": "Streams base64 encoded audio chunks via Server-Sent Events (SSE).\nClients connect to this endpoint to receive live audio data.",
+        "operationId": "stream_audio_stream_audio_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/speak": {
+      "post": {
+        "tags": [
+          "tts"
+        ],
+        "summary": "Speak",
+        "operationId": "speak_speak_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SpeakRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/feedback/phi3/": {
+      "post": {
+        "tags": [
+          "feedback"
+        ],
+        "summary": "Submit Phi3 Feedback",
+        "operationId": "submit_phi3_feedback_feedback_phi3__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FeedbackItem"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/adapters/swap": {
+      "post": {
+        "tags": [
+          "meta"
+        ],
+        "summary": "Swap Phi3 Adapter",
+        "description": "Reload the Phi-3 model and adapter from disk.",
+        "operationId": "swap_phi3_adapter_adapters_swap_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "tags": [
+          "meta"
+        ],
+        "summary": "Health",
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "FeedbackItem": {
+        "title": "FeedbackItem",
+        "required": [
+          "transaction_id",
+          "feedback_type",
+          "timestamp"
+        ],
+        "type": "object",
+        "properties": {
+          "transaction_id": {
+            "title": "Transaction Id",
+            "type": "string"
+          },
+          "feedback_type": {
+            "title": "Feedback Type",
+            "type": "string"
+          },
+          "feedback_content": {
+            "title": "Feedback Content"
+          },
+          "timestamp": {
+            "title": "Timestamp",
+            "type": "string"
+          },
+          "corrected_proposal": {
+            "title": "Corrected Proposal",
+            "type": "object"
+          },
+          "schema_version": {
+            "title": "Schema Version",
+            "type": "string",
+            "default": "1.0"
+          }
+        }
+      },
+      "HTTPValidationError": {
+        "title": "HTTPValidationError",
+        "type": "object",
+        "properties": {
+          "detail": {
+            "title": "Detail",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            }
+          }
+        }
+      },
+      "PromptRequest": {
+        "title": "PromptRequest",
+        "required": [
+          "prompt"
+        ],
+        "type": "object",
+        "properties": {
+          "prompt": {
+            "title": "Prompt",
+            "type": "string"
+          },
+          "max_length": {
+            "title": "Max Length",
+            "type": "integer",
+            "default": 256
+          }
+        }
+      },
+      "ScoreRequest": {
+        "title": "ScoreRequest",
+        "required": [
+          "proposal"
+        ],
+        "type": "object",
+        "properties": {
+          "proposal": {
+            "title": "Proposal",
+            "type": "object"
+          },
+          "context": {
+            "title": "Context",
+            "type": "string"
+          }
+        }
+      },
+      "SpeakRequest": {
+        "title": "SpeakRequest",
+        "required": [
+          "text"
+        ],
+        "type": "object",
+        "properties": {
+          "text": {
+            "title": "Text",
+            "type": "string"
+          },
+          "exaggeration": {
+            "title": "Exaggeration",
+            "type": "number",
+            "default": 0.5
+          },
+          "ref_wav_b64": {
+            "title": "Ref Wav B64",
+            "type": "string"
+          }
+        }
+      },
+      "UnifiedPromptRequest": {
+        "title": "UnifiedPromptRequest",
+        "required": [
+          "prompt"
+        ],
+        "type": "object",
+        "properties": {
+          "prompt": {
+            "title": "Prompt",
+            "type": "string"
+          },
+          "max_length": {
+            "title": "Max Length",
+            "type": "integer",
+            "default": 256
+          },
+          "model_id": {
+            "title": "Model Id",
+            "type": "string",
+            "default": "hermes"
+          }
+        }
+      },
+      "ValidationError": {
+        "title": "ValidationError",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "loc": {
+            "title": "Location",
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            }
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -1,0 +1,3 @@
+# API Documentation
+
+<swagger-ui src="openapi.json" />

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,11 @@
+site_name: Osiris Documentation
+site_url: https://example.com
+docs_dir: docs
+nav:
+  - Home: index.html
+  - API: openapi.md
+plugins:
+  - search
+  - swagger-ui-tag
+theme:
+  name: material

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,3 @@
+mkdocs>=1.5
+mkdocs-material
+mkdocs-swagger-ui-tag

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+import json
+from pathlib import Path
+from unittest.mock import patch
+import sys
+from types import ModuleType
+from fastapi.openapi.utils import get_openapi
+
+mock_loader = ModuleType('llm_sidecar.loader')
+mock_loader.load_hermes_model = lambda: None
+mock_loader.load_phi3_model = lambda: None
+mock_loader.get_hermes_model_and_tokenizer = lambda: (None, None)
+mock_loader.get_phi3_model_and_tokenizer = lambda: (None, None)
+mock_loader.MICRO_LLM_MODEL_PATH = ''
+mock_loader.phi3_adapter_date = None
+mock_tts = ModuleType('llm_sidecar.tts')
+mock_tts.ChatterboxTTS = lambda *a, **k: None
+mock_torch = ModuleType('torch')
+mock_torch.cuda = ModuleType('torch.cuda')
+mock_torch.cuda.is_available = lambda: False
+mock_outlines = ModuleType('outlines')
+mock_outlines.generate = lambda *a, **k: None
+mock_lancedb = ModuleType('lancedb')
+mock_lancedb.pydantic = ModuleType('lancedb.pydantic')
+mock_lancedb.pydantic.LanceModel = object
+mock_lancedb.connect = lambda *a, **k: type('DB', (), {'open_table': lambda *a, **k: None})()
+mock_redis = ModuleType('redis')
+mock_redis.asyncio = ModuleType('redis.asyncio')
+mock_redis.asyncio.client = ModuleType('redis.asyncio.client')
+mock_redis.asyncio.client.PubSub = object
+mock_redis.exceptions = ModuleType('redis.exceptions')
+mock_redis.exceptions.RedisError = Exception
+mock_redis.asyncio.from_url = lambda *a, **k: None
+
+with patch.dict(sys.modules, {
+    'llm_sidecar.loader': mock_loader,
+    'llm_sidecar.tts': mock_tts,
+    'torch': mock_torch,
+    'lancedb': mock_lancedb,
+    'lancedb.pydantic': mock_lancedb.pydantic,
+    'outlines': mock_outlines,
+    'redis.asyncio': mock_redis.asyncio,
+    'redis.asyncio.client': mock_redis.asyncio.client,
+    'redis.exceptions': mock_redis.exceptions,
+    'redis': mock_redis,
+}):
+    import importlib
+    dummy_llm = ModuleType('osiris.llm_sidecar')
+    sys.modules['osiris.llm_sidecar'] = dummy_llm
+    server = importlib.import_module('osiris.server')
+
+schema = get_openapi(
+    title=server.app.title,
+    version=server.app.version,
+    description=server.app.description,
+    routes=server.app.routes,
+)
+
+Path("docs").mkdir(exist_ok=True)
+with open("docs/openapi.json", "w") as f:
+    json.dump(schema, f, indent=2)
+print("OpenAPI schema written to docs/openapi.json")

--- a/tests/docker-compose.traces.yaml
+++ b/tests/docker-compose.traces.yaml
@@ -1,0 +1,33 @@
+version: '3.8'
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.92.0
+    command: ["--config=/etc/otel-config.yaml"]
+    volumes:
+      - ./tests/otel-collector-config.yaml:/etc/otel-config.yaml
+    ports:
+      - "4318:4318"
+  llm-sidecar:
+    image: python:3.10-slim
+    working_dir: /app
+    volumes:
+      - .:/app
+    environment:
+      - PYTHONPATH=/app
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+    command: python tests/mock_sidecar.py
+    depends_on:
+      - otel-collector
+    ports:
+      - "8000:8000"
+  orchestrator:
+    image: python:3.10-slim
+    working_dir: /app
+    volumes:
+      - .:/app
+    environment:
+      - PYTHONPATH=/app
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+    command: python tests/mock_orchestrator.py
+    depends_on:
+      - otel-collector

--- a/tests/mock_orchestrator.py
+++ b/tests/mock_orchestrator.py
@@ -1,0 +1,25 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch, AsyncMock, MagicMock
+from common.otel_init import init_otel
+from opentelemetry import trace
+
+# Patch heavy dependencies before import
+with patch('osiris_policy.orchestrator.EventBus'), \
+     patch('osiris_policy.orchestrator.log_run'), \
+     patch('osiris_policy.orchestrator.init_advice_table'), \
+     patch('osiris_policy.orchestrator.market_tick_listener', new=AsyncMock()), \
+     patch('osiris_policy.orchestrator.build_graph', return_value=MagicMock(ainvoke=AsyncMock(return_value={}))) as _:
+    from osiris_policy import orchestrator
+
+# Initialize OTEL and run a span around main_async
+init_otel()
+tracer = trace.get_tracer(__name__)
+args = SimpleNamespace(redis_url="redis://localhost:6379/0", market_channel="market.ticks", ticks_per_proposal=1)
+
+async def run():
+    with tracer.start_as_current_span("orchestrator.run"):
+        await orchestrator.main_async(args)
+
+if __name__ == "__main__":
+    asyncio.run(run())

--- a/tests/mock_sidecar.py
+++ b/tests/mock_sidecar.py
@@ -1,0 +1,19 @@
+from unittest.mock import patch, MagicMock, AsyncMock
+import uvicorn
+
+# Patch heavy model loading before importing server
+with patch('llm_sidecar.loader.load_hermes_model'), \
+     patch('llm_sidecar.loader.load_phi3_model'), \
+     patch('llm_sidecar.tts.ChatterboxTTS'):
+    import osiris.server as server
+
+# Patch generation helpers to return quickly
+server._generate_hermes_text = AsyncMock(return_value="ok")
+server._generate_phi3_json = AsyncMock(return_value={"ok": True})
+server.hermes_model = MagicMock()
+server.hermes_tokenizer = MagicMock()
+server.phi3_model = MagicMock()
+server.phi3_tokenizer = MagicMock()
+
+if __name__ == "__main__":
+    uvicorn.run(server.app, host="0.0.0.0", port=8000)

--- a/tests/otel-collector-config.yaml
+++ b/tests/otel-collector-config.yaml
@@ -1,0 +1,14 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+      grpc:
+exporters:
+  logging:
+    loglevel: debug
+    verbosity: detailed
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [logging]

--- a/tests/test_traces.py
+++ b/tests/test_traces.py
@@ -1,0 +1,41 @@
+import subprocess
+import time
+import requests
+import os
+import re
+from collections import Counter
+
+COMPOSE_FILE = os.path.join(os.path.dirname(__file__), "docker-compose.traces.yaml")
+
+
+def _compose_cmd(*args):
+    return ["docker", "compose", "-f", COMPOSE_FILE, *args]
+
+
+def setup_module(module):
+    subprocess.run(_compose_cmd("up", "-d"), check=True)
+    # wait for sidecar
+    for _ in range(30):
+        try:
+            r = requests.post("http://localhost:8000/generate/", json={"prompt": "hi"})
+            if r.status_code == 200:
+                break
+        except Exception:
+            pass
+        time.sleep(1)
+    else:
+        raise RuntimeError("llm-sidecar did not start")
+
+
+def teardown_module(module):
+    subprocess.run(_compose_cmd("down", "-v"), check=True)
+
+
+def test_traces_collected():
+    requests.post("http://localhost:8000/generate/", json={"prompt": "test"})
+    time.sleep(3)
+    logs = subprocess.check_output(_compose_cmd("logs", "otel-collector"), text=True)
+    span_names = re.findall(r"Name:\s+(.*)", logs)
+    counts = Counter(span_names)
+    assert any("/generate" in name for name in counts), "generate span missing"
+    assert counts.get("orchestrator.run", 0) >= 1


### PR DESCRIPTION
## Summary
- add integration test harness for OTEL traces
- provide mocked sidecar/orchestrator containers
- generate OpenAPI schema via new Make target
- configure MkDocs with Swagger UI and deploy workflow

## Testing
- `make openapi`
- `pytest tests/test_traces.py` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'docker')*
- `pytest -k 'not traces'` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684097e73918832fa721b7e9eeeed27d