### PR TITLE
feat(otel): instrument llm_sidecar with OpenTelemetry

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,2 +1,5 @@
 HERMES_CTX=6144
 ENABLE_METRICS=true
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+OTEL_SERVICE_NAME=osiris_llm_sidecar
+OTEL_TRACES_SAMPLER=parentbased_always_on

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ cp .env.template .env      # default Hermes ctx = 6144
 make rebuild
 # Optional: run an OpenTelemetry collector
 docker run -d -p 4317:4317 otel/opentelemetry-collector-contrib:0.92.0
+# If using OpenTelemetry locally, set the OTEL variables in .env
+echo "OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318" >> .env
+echo "OTEL_SERVICE_NAME=osiris_llm_sidecar" >> .env
+echo "OTEL_TRACES_SAMPLER=parentbased_always_on" >> .env
 ```
 This will build the images (if necessary, without cache) and start the services defined in `docker-compose.yaml` (typically `llm-sidecar` and `redis`) in detached mode.
 To view logs for a service (e.g., `llm-sidecar`), use `make logs SVC=llm-sidecar` or simply `make logs` (which defaults to `llm-sidecar`).

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -29,7 +29,8 @@ services:
       - ./lancedb_data:/app/lancedb_data
     environment:
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT}
-      - OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-llm-sidecar}
+      - OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-osiris_llm_sidecar}
+      - OTEL_TRACES_SAMPLER=${OTEL_TRACES_SAMPLER:-parentbased_always_on}
       - ENABLE_METRICS=${ENABLE_METRICS:-true}
     # Adding a healthcheck can be useful for production, but is optional here
     # healthcheck:

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,5 @@ opentelemetry-instrumentation-logging
 opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk
 opentelemetry-exporter-otlp
+opentelemetry-api
 prometheus-fastapi-instrumentator>=6.1


### PR DESCRIPTION
## Summary
- add `opentelemetry-api` to requirements
- configure OTEL variables in `.env.template`
- set OTEL options for `llm-sidecar` service in compose file
- document OTEL environment variables in README

## Testing
- `pre-commit run --files requirements.txt .env.template docker/compose.yaml README.md osiris/server.py common/otel_init.py`
- `PYTHONPATH=. pytest tests/test_server.py -k test_generate_hermes_default_model_id -q` *(fails: ModuleNotFoundError: No module named 'onnx')*

------
https://chatgpt.com/codex/tasks/task_e_6840b8c5d374832fb8f6cec624978a3a