### PR TITLE
Document OTEL env vars

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,2 +1,5 @@
 HERMES_CTX=6144
 ENABLE_METRICS=true
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+OTEL_SERVICE_NAME=osiris_llm_sidecar
+OTEL_TRACES_SAMPLER=parentbased_always_on

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,4 +1,16 @@
 ---
+## OpenTelemetry Configuration
+
+The services emit traces using [OpenTelemetry](https://opentelemetry.io/). Set the following environment variables to enable tracing locally:
+
+```
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+OTEL_SERVICE_NAME=osiris_llm_sidecar
+OTEL_TRACES_SAMPLER=parentbased_always_on
+```
+
+Adjust `OTEL_SERVICE_NAME` for other components (e.g. `osiris_orchestrator`). Traces can be collected with any OTLP compatible collector.
+
 ## Prometheus Alert Rules
 
 Osiris includes a set of predefined Prometheus alert rules to help monitor key aspects of the system. These rules are defined in `ops/prometheus/osiris_alerts.yaml`.


### PR DESCRIPTION
## Summary
- document OTEL environment variables in docs
- update `.env.template` with tracing variables

## Testing
- `pytest -q` *(fails: 8 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840b8e42454832f9b2c81cbad2c9cf5