### PR TITLE
Implement semantic versioning release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
     env:
       TAG: ${{ github.ref_name }}
@@ -24,6 +24,30 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install semantic-release
+        run: pip install python-semantic-release
+
+      - name: Determine next version
+        if: github.event_name == 'workflow_dispatch'
+        id: semver
+        run: |
+          NEXT_TAG=$(semantic-release version --print-tag --no-commit --no-tag --no-changelog --no-push)
+          echo "TAG=$NEXT_TAG" >> "$GITHUB_ENV"
+          echo "tag=$NEXT_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Create Git tag
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git tag "$TAG"
+          git push origin "$TAG"
 
       - name: Determine platforms
         id: platforms
@@ -57,4 +81,11 @@ jobs:
           registry_user: ${{ github.actor }}
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           platforms: ${{ steps.platforms.outputs.PLATFORMS }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ env.TAG }}
+          name: ${{ env.TAG }}
+          generate_release_notes: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,7 @@ target-version = "py310"
 line-length = 88
 required-version = "0.4.4"
 select = ["E9"]
+
+[tool.semantic_release]
+version_variable = "pyproject.toml:version"
+tag_format = "v{version}"

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 # light-weight stubs / testing libs
 onnxruntime==1.17.3         # CPU wheel only, tiny
+python-semantic-release==10.0.2


### PR DESCRIPTION
## Summary
- integrate `python-semantic-release`
- configure semantic-release in pyproject
- update release workflow to calculate version, push tags, build multi-arch Docker images, and create releases
- provide a starter `CHANGELOG.md`

## Testing
- `pre-commit run --files .github/workflows/release.yaml pyproject.toml requirements-ci.txt CHANGELOG.md`
- `pytest -k ""` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_6840bd432144832f8e5219c69d3bfbe4