### PR TITLE
feat(helm): add Prometheus scrape and GPU node options

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,22 @@ azrPlanner:
   # ... other configuration ...
 ```
 
+Enabling Prometheus scraping and GPU scheduling can be done through additional
+`values.yaml` configuration:
+
+```yaml
+llmSidecar:
+  prometheusScrape:
+    enabled: true
+  nodeSelector:
+    accelerator: nvidia-tesla-t4
+  resources:
+    limits:
+      nvidia.com/gpu: 1
+    requests:
+      nvidia.com/gpu: 1
+```
+
 ### Canary Deployment
 
 Use `helm/osiris/values-canary.yaml` to deploy a canary release. This file

--- a/helm/osiris/templates/llm-sidecar-deployment.yaml
+++ b/helm/osiris/templates/llm-sidecar-deployment.yaml
@@ -16,6 +16,12 @@ spec:
       labels:
         {{- include "osiris.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: llm-sidecar
+      {{- if .Values.llmSidecar.prometheusScrape.enabled }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "{{ .Values.llmSidecar.prometheusScrape.path }}"
+        prometheus.io/port: "{{ .Values.llmSidecar.prometheusScrape.port }}"
+      {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/osiris/templates/llm-sidecar-service.yaml
+++ b/helm/osiris/templates/llm-sidecar-service.yaml
@@ -5,6 +5,12 @@ metadata:
   labels:
     {{- include "osiris.labels" . | nindent 4 }}
     app.kubernetes.io/component: llm-sidecar
+  {{- if .Values.llmSidecar.prometheusScrape.enabled }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: "{{ .Values.llmSidecar.prometheusScrape.path }}"
+    prometheus.io/port: "{{ .Values.llmSidecar.prometheusScrape.port }}"
+  {{- end }}
 spec:
   type: {{ .Values.llmSidecar.service.type }}
   ports:

--- a/helm/osiris/values.yaml
+++ b/helm/osiris/values.yaml
@@ -67,6 +67,14 @@ llmSidecar:
     type: ClusterIP
     port: 8000 # Matches docker/compose.yaml
 
+  # When enabled, these annotations allow Prometheus to scrape metrics from the
+  # llm-sidecar container. Adjust the path and port if your metrics endpoint
+  # differs.
+  prometheusScrape:
+    enabled: false
+    path: /metrics
+    port: 8000
+
   # GPU node selector. Adapt to your cluster's GPU node labels.
   # Example: if nodes are labeled 'accelerator=nvidia-tesla-v100' or 'gpu=true'
   nodeSelector: {}


### PR DESCRIPTION
## Summary
- allow optional Prometheus annotations on llm-sidecar deployment and service
- expose `prometheusScrape` options and GPU node selector in `values.yaml`
- document Prometheus/GPU configuration in README

## Testing
- `pre-commit run --files helm/osiris/templates/llm-sidecar-deployment.yaml helm/osiris/templates/llm-sidecar-service.yaml helm/osiris/values.yaml README.md`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_6840bf864f8c832f9208e690dad16ff3