### PR TITLE
Compose integration tests for health endpoint

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -66,3 +66,13 @@ def test_metrics_endpoint(run_compose):
     response = requests.get("http://localhost:8000/metrics")
     assert response.status_code == 200
     assert "python_gc_objects_collected_total" in response.text
+
+
+@pytest.mark.compose
+def test_health_endpoint(run_compose):
+    response = requests.get("http://localhost:8000/health")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] in {"ok", "partial_error", "error"}
+    assert "hermes_loaded" in data
+    assert "phi3_loaded" in data


### PR DESCRIPTION
## Summary
- add `/health` check to Docker compose-based tests

## Testing
- `pre-commit run --files tests/test_metrics.py`
- `pytest -k "compose" -vv` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_6840bf78cb38832fa282efe6d92bf5b0