### PR TITLE
Add k6 load test harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,8 +453,8 @@ helm upgrade --install osiris-canary helm/osiris \
 | Links | Links |
 | --- | --- |
 | [Docs](docs/) | [Developer Guide](docs/DEV_GUIDE.md) |
-| [DGM Paper](docs/research/DGM_mapping.md) | [Prometheus Alerts](ops/prometheus/alerts.yaml) |
-| [Helm Chart](helm/osiris) | |
+| [Load Testing](docs/LOAD_TESTING.md) | [Prometheus Alerts](ops/prometheus/alerts.yaml) |
+| [DGM Paper](docs/research/DGM_mapping.md) | [Helm Chart](helm/osiris) |
 
 [ci-badge]: https://github.com/OWNER/REPO/actions/workflows/ci.yaml/badge.svg
 [ci]: https://github.com/OWNER/REPO/actions/workflows/ci.yaml

--- a/docs/LOAD_TESTING.md
+++ b/docs/LOAD_TESTING.md
@@ -1,0 +1,46 @@
+# Load Testing Osiris with k6
+
+This guide explains how to run a basic load test against the `llm_sidecar` service using [k6](https://k6.io/).
+
+## Prerequisites
+- Docker and Docker Compose installed
+- The Osiris repository cloned locally
+- k6 installed locally (`brew install k6` on macOS, `choco install k6` on Windows) or run via Docker
+
+## Starting the stack
+Launch the sidecar and its dependencies:
+
+```bash
+cd docker
+docker compose up redis llm-sidecar
+```
+
+Wait until the API is available at `http://localhost:8000`.
+
+## Running the load test
+From the repository root, execute:
+
+```bash
+k6 run scripts/load/k6_sidecar_load.js
+```
+
+If k6 is not installed, you can run it via Docker:
+
+```bash
+docker run --rm -i --network host -v $(pwd)/scripts/load/k6_sidecar_load.js:/script.js grafana/k6 run /script.js
+```
+
+The script sends requests to `/generate` with a sample prompt and checks the `/metrics` endpoint. It reports request rates, P95/P99 latencies and error rates in the output summary.
+
+Set `OSIRIS_URL` to target a different base URL:
+
+```bash
+OSIRIS_URL=http://localhost:8000 k6 run scripts/load/k6_sidecar_load.js
+```
+
+## Stopping services
+Press `Ctrl+C` to stop k6 when done. Shut down the stack with:
+
+```bash
+docker compose down
+```

--- a/scripts/load/k6_sidecar_load.js
+++ b/scripts/load/k6_sidecar_load.js
@@ -1,0 +1,30 @@
+import http from 'k6/http';
+import { sleep, check } from 'k6';
+
+export const options = {
+  stages: [
+    { duration: '10s', target: 5 },
+    { duration: '30s', target: 5 },
+    { duration: '5s', target: 0 },
+  ],
+  summaryTrendStats: ['avg', 'p(95)', 'p(99)', 'min', 'max'],
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    http_req_duration: ['p(95)<1000', 'p(99)<2000'],
+  },
+};
+
+const BASE_URL = __ENV.OSIRIS_URL || 'http://localhost:8000';
+
+export default function () {
+  const payload = JSON.stringify({ prompt: 'hello', model_id: 'phi3', max_length: 16 });
+  const params = { headers: { 'Content-Type': 'application/json' } };
+
+  const genRes = http.post(`${BASE_URL}/generate/`, payload, params);
+  check(genRes, { 'generate status 200': (r) => r.status === 200 });
+
+  const metricsRes = http.get(`${BASE_URL}/metrics`);
+  check(metricsRes, { 'metrics status 200': (r) => r.status === 200 });
+
+  sleep(1);
+}


### PR DESCRIPTION
## Summary
- add k6 load test script for the llm_sidecar service
- document how to run the load test locally
- link new guide from README

## Testing
- `pre-commit run --files README.md docs/LOAD_TESTING.md scripts/load/k6_sidecar_load.js`

------
https://chatgpt.com/codex/tasks/task_e_6840bfa890a4832fad2487c443bb634c