### PR TITLE
test(chaos): implement Redis restart chaos job

### DIFF
--- a/.github/workflows/chaos-redis.yaml
+++ b/.github/workflows/chaos-redis.yaml
@@ -1,0 +1,139 @@
+name: Redis Chaos Test
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  redis-chaos:
+    runs-on: ubuntu-latest
+    env:
+      TORCH_VERSION: "2.2.2+cu121"
+      CHAOS_MODE: "1"
+      PYTHONUNBUFFERED: "1"
+      LANCEDB_URI: "./lancedb_data"
+      REDIS_CONTAINER_ID: ${{ job.services.redis.id }}
+
+    services:
+      redis:
+        image: redis:latest
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-torch-${{ env.TORCH_VERSION }}
+
+      - name: Osiris Setup
+        uses: ./.github/actions/osiris-setup
+        with:
+          python-version: '3.10'
+          install-requirements: 'true'
+          system-packages: 'jq docker-compose'
+
+      - name: Install test-only deps
+        run: pip install -r requirements-tests.txt
+
+      - name: Install additional deps
+        run: |
+          PIP_INSTALL_OPTIONS=""
+          if [ -f constraints_cpu.txt ]; then
+            PIP_INSTALL_OPTIONS="-c constraints_cpu.txt --extra-index-url https://download.pytorch.org/whl/cpu"
+          elif [ -f constraints.txt ]; then
+            PIP_INSTALL_OPTIONS="-c constraints.txt"
+          fi
+          python -m pip install lancedb redis pandas $PIP_INSTALL_OPTIONS
+
+      - name: Create LanceDB data directory
+        run: mkdir -p ${{ env.LANCEDB_URI }}
+
+      - name: Start Docker Compose services (LanceDB, LLM Sidecar)
+        run: |
+          docker-compose -f docker/docker-compose.yml up -d lancedb
+          docker-compose -f docker/compose.yaml up -d llm-sidecar
+
+      - name: Wait for services to be healthy
+        run: |
+          echo "Waiting for services to start..."
+          sleep 5
+          counter=0
+          until docker exec ${{ job.services.redis.id }} redis-cli ping | grep PONG; do
+            sleep 5
+            counter=$((counter+1))
+            if [ $counter -ge 12 ]; then
+              echo "Redis did not start in time."
+              docker ps -a
+              docker logs ${{ job.services.redis.id }}
+              exit 1
+            fi
+          done
+          echo "Redis is up."
+          sleep 5
+
+      - name: Run LanceDB migrations
+        run: docker compose -f docker/compose.yaml exec -T llm-sidecar python /app/scripts/migrate_lancedb_20250604.py
+
+      - name: Start Orchestrator in background
+        run: |
+          python osiris_policy/orchestrator.py --redis_url redis://localhost:6379/0 --ticks_per_proposal 3 --db_path ${{ env.LANCEDB_URI }} &
+          sleep 5
+
+      - name: Start chaos script in background
+        run: |
+          chmod +x scripts/chaos_redis_restart.py
+          ./scripts/chaos_redis_restart.py &
+          sleep 5
+
+      - name: Start CI Tick Publisher in background
+        run: |
+          python scripts/ci_tick_publisher.py --duration 60 &
+          sleep 5
+
+      - name: Wait for test duration
+        run: |
+          echo "Running chaos test for 70 seconds..."
+          sleep 70
+
+      - name: Stop chaos script
+        run: |
+          pkill -f scripts/chaos_redis_restart.py || true
+          sleep 2
+
+      - name: Stop tick publisher
+        run: |
+          pkill -f scripts/ci_tick_publisher.py || true
+          sleep 2
+
+      - name: Stop orchestrator
+        run: |
+          pkill -f osiris_policy/orchestrator.py || true
+          sleep 5
+
+      - name: Check for advice in LanceDB
+        run: python scripts/ci_check_advice.py --db-path ${{ env.LANCEDB_URI }} --retries 3 --retry-delay 5
+
+      - name: Cleanup Docker services
+        if: always()
+        run: |
+          docker-compose -f docker/compose.yaml logs
+          docker-compose -f docker/docker-compose.yml logs
+          docker-compose -f docker/compose.yaml down -v --remove-orphans || true
+          docker-compose -f docker/docker-compose.yml down -v --remove-orphans || true
+
+      - name: Check Docker disk space and running containers
+        if: always()
+        run: |
+          docker system df
+          docker ps -a

--- a/osiris/scripts/chaos_redis_restart.py
+++ b/osiris/scripts/chaos_redis_restart.py
@@ -1,0 +1,1 @@
+../../scripts/chaos_redis_restart.py

--- a/scripts/chaos_redis_restart.py
+++ b/scripts/chaos_redis_restart.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+import os
+import subprocess
+import time
+from datetime import datetime
+
+
+def log(msg: str) -> None:
+    print(f"[{datetime.utcnow().isoformat()}] {msg}", flush=True)
+
+
+def restart_redis(container_id: str, downtime: int) -> None:
+    log(f"Stopping Redis container {container_id}")
+    subprocess.run(["docker", "stop", container_id], check=True)
+    log(f"Redis stopped. Sleeping for {downtime}s")
+    time.sleep(downtime)
+    log(f"Starting Redis container {container_id}")
+    subprocess.run(["docker", "start", container_id], check=True)
+    log("Redis container restarted")
+
+
+def main() -> None:
+    cid = os.environ.get("REDIS_CONTAINER_ID")
+    if not cid:
+        log("REDIS_CONTAINER_ID env var not set; exiting")
+        return
+    cycles = int(os.environ.get("CHAOS_REDIS_CYCLES", "3"))
+    downtime = int(os.environ.get("CHAOS_REDIS_DOWNTIME", "5"))
+    sleep_between = int(os.environ.get("CHAOS_REDIS_SLEEP", "10"))
+
+    log(
+        f"Starting Redis chaos: cycles={cycles} downtime={downtime}s sleep={sleep_between}s"
+    )
+    for i in range(cycles):
+        log(f"Cycle {i+1}/{cycles}")
+        restart_redis(cid, downtime)
+        if i < cycles - 1:
+            log(f"Sleeping {sleep_between}s before next cycle")
+            time.sleep(sleep_between)
+    log("Redis chaos test complete")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add chaos_redis_restart.py to simulate Redis downtime
- link the new script into package
- add GitHub workflow 'Redis Chaos Test'

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_6840bf9d5624832f84dee13861e4a4db