### PR TITLE
feat(iac): add Terraform module for Osiris helm

### DIFF
--- a/infra/terraform/environments/dev/README.md
+++ b/infra/terraform/environments/dev/README.md
@@ -1,0 +1,10 @@
+# Osiris Development Environment
+
+This example shows how to deploy Osiris using the Terraform module.
+
+```bash
+terraform init
+terraform apply
+```
+
+Adjust the `kubeconfig` variable if needed to point to your cluster configuration.

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_version = ">= 1.3"
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.11"
+    }
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = var.kubeconfig
+  }
+}
+
+provider "kubernetes" {
+  config_path = var.kubeconfig
+}
+
+module "osiris" {
+  source = "../../modules/osiris_sidecar"
+
+  namespace                     = var.namespace
+  image_tag                     = var.image_tag
+  llm_sidecar_image_tag         = var.llm_sidecar_image_tag
+  otel_collector_endpoint       = var.otel_collector_endpoint
+  llm_sidecar_gpu_node_selector = var.llm_sidecar_gpu_node_selector
+}

--- a/infra/terraform/environments/dev/outputs.tf
+++ b/infra/terraform/environments/dev/outputs.tf
@@ -1,0 +1,11 @@
+output "release_name" {
+  value = module.osiris.release_name
+}
+
+output "namespace" {
+  value = module.osiris.namespace
+}
+
+output "status" {
+  value = module.osiris.status
+}

--- a/infra/terraform/environments/dev/variables.tf
+++ b/infra/terraform/environments/dev/variables.tf
@@ -1,0 +1,35 @@
+variable "kubeconfig" {
+  description = "Path to kubeconfig file"
+  type        = string
+  default     = "~/.kube/config"
+}
+
+variable "namespace" {
+  description = "Namespace to deploy Osiris"
+  type        = string
+  default     = "osiris-dev"
+}
+
+variable "image_tag" {
+  description = "Orchestrator image tag"
+  type        = string
+  default     = "latest"
+}
+
+variable "llm_sidecar_image_tag" {
+  description = "LLM sidecar image tag"
+  type        = string
+  default     = "latest"
+}
+
+variable "otel_collector_endpoint" {
+  description = "OTEL collector endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "llm_sidecar_gpu_node_selector" {
+  description = "Node selector labels for GPU nodes"
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/osiris_sidecar/README.md
+++ b/infra/terraform/modules/osiris_sidecar/README.md
@@ -1,0 +1,35 @@
+# Osiris Helm Chart Terraform Module
+
+This module deploys the Osiris application using its Helm chart. It exposes variables for common configuration options.
+
+## Usage
+
+```hcl
+module "osiris" {
+  source = "../modules/osiris_sidecar"
+
+  namespace               = "osiris-dev"
+  image_tag               = "1.1.0"
+  llm_sidecar_image_tag   = "1.1.0"
+  otel_collector_endpoint = "http://otel-collector:4317"
+}
+```
+
+Run `terraform init` and `terraform apply` in an environment directory to deploy the chart.
+
+## Variables
+
+- `release_name` – Helm release name.
+- `namespace` – Namespace for deployment.
+- `chart_path` – Path to the Helm chart.
+- `chart_version` – Version of the chart (optional).
+- `image_tag` – Orchestrator image tag.
+- `replica_count` – Orchestrator replica count.
+- `llm_sidecar_image_tag` – LLM sidecar image tag.
+- `llm_sidecar_replica_count` – LLM sidecar replica count.
+- `llm_sidecar_gpu_node_selector` – Map of node selector labels for GPU scheduling.
+- `llm_sidecar_resources` – Resource requests and limits for the sidecar.
+- `otel_collector_endpoint` – OTEL collector endpoint.
+- `additional_values` – Additional values map passed to the chart.
+
+Outputs provide the release name, namespace, and deployment status.

--- a/infra/terraform/modules/osiris_sidecar/main.tf
+++ b/infra/terraform/modules/osiris_sidecar/main.tf
@@ -1,0 +1,28 @@
+resource "helm_release" "osiris" {
+  name             = var.release_name
+  namespace        = var.namespace
+  chart            = var.chart_path
+  create_namespace = true
+  version          = var.chart_version
+
+  values = [yamlencode({
+    replicaCount = var.replica_count
+    image = {
+      tag = var.image_tag
+    }
+    config = {
+      OTEL_EXPORTER_OTLP_ENDPOINT = var.otel_collector_endpoint
+    }
+    llmSidecar = {
+      replicaCount = var.llm_sidecar_replica_count
+      image = {
+        tag = var.llm_sidecar_image_tag
+      }
+      nodeSelector = var.llm_sidecar_gpu_node_selector
+      resources    = var.llm_sidecar_resources
+      config = {
+        OTEL_EXPORTER_OTLP_ENDPOINT = var.otel_collector_endpoint
+      }
+    }
+  })]
+}

--- a/infra/terraform/modules/osiris_sidecar/outputs.tf
+++ b/infra/terraform/modules/osiris_sidecar/outputs.tf
@@ -1,0 +1,14 @@
+output "release_name" {
+  value       = helm_release.osiris.name
+  description = "Name of the Helm release"
+}
+
+output "namespace" {
+  value       = helm_release.osiris.namespace
+  description = "Kubernetes namespace where Osiris is deployed"
+}
+
+output "status" {
+  value       = helm_release.osiris.status
+  description = "Deployment status"
+}

--- a/infra/terraform/modules/osiris_sidecar/variables.tf
+++ b/infra/terraform/modules/osiris_sidecar/variables.tf
@@ -1,0 +1,71 @@
+variable "release_name" {
+  description = "Helm release name"
+  type        = string
+  default     = "osiris"
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace to deploy Osiris"
+  type        = string
+  default     = "osiris"
+}
+
+variable "chart_path" {
+  description = "Path to the Osiris Helm chart"
+  type        = string
+  default     = "../../../helm/osiris"
+}
+
+variable "chart_version" {
+  description = "Version of the chart to deploy. Set to null to use local path without version"
+  type        = string
+  default     = null
+}
+
+variable "image_tag" {
+  description = "Osiris orchestrator image tag"
+  type        = string
+  default     = "latest"
+}
+
+variable "replica_count" {
+  description = "Number of orchestrator replicas"
+  type        = number
+  default     = 1
+}
+
+variable "llm_sidecar_image_tag" {
+  description = "LLM sidecar image tag"
+  type        = string
+  default     = "latest"
+}
+
+variable "llm_sidecar_replica_count" {
+  description = "Number of LLM sidecar replicas"
+  type        = number
+  default     = 1
+}
+
+variable "llm_sidecar_gpu_node_selector" {
+  description = "Node selector map for scheduling the LLM sidecar on GPU nodes"
+  type        = map(string)
+  default     = {}
+}
+
+variable "llm_sidecar_resources" {
+  description = "Resource requests and limits for the LLM sidecar"
+  type        = any
+  default     = {}
+}
+
+variable "otel_collector_endpoint" {
+  description = "OTEL collector endpoint for traces"
+  type        = string
+  default     = ""
+}
+
+variable "additional_values" {
+  description = "Additional values to merge into the Helm release"
+  type        = map(any)
+  default     = {}
+}


### PR DESCRIPTION
## Summary
- add reusable Terraform module to install the Osiris Helm chart
- document module usage
- provide a dev environment example using the module

## Testing
- `terraform fmt -recursive infra/terraform`
- `terraform init -backend=false` *(fails: could not connect to registry.terraform.io)*
- `pytest -k test_db -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_6840c14f6ffc832fb85610a0cf32acb4