### PR TITLE
feat(testing): expand k6 load tests and add smoke workflow

### DIFF
--- a/.github/workflows/k6-smoke.yaml
+++ b/.github/workflows/k6-smoke.yaml
@@ -1,0 +1,53 @@
+name: k6 Smoke Test
+
+on:
+  push:
+    branches: [ "main" ]
+  schedule:
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+
+jobs:
+  k6-smoke:
+    runs-on: ubuntu-latest
+    env:
+      TORCH_VERSION: "2.2.2+cu121"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-torch-${{ env.TORCH_VERSION }}
+
+      - name: Osiris Setup
+        uses: ./.github/actions/osiris-setup
+        with:
+          install-requirements: 'false'
+          system-packages: 'jq docker-compose'
+
+      - name: Install k6
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y k6
+
+      - name: Copy .env template
+        run: cp .env.template .env
+
+      - name: Start llm-sidecar
+        run: docker compose -f docker/compose.yaml up -d llm-sidecar
+
+      - name: Wait for service
+        run: |
+          echo "Waiting for llm-sidecar service to start..."
+          timeout 60s bash -c 'until curl -sf http://localhost:8000/health; do sleep 2; done'
+
+      - name: Run k6 smoke test
+        run: |
+          OSIRIS_URL=http://localhost:8000 k6 run scripts/load/k6_read_heavy.js
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f docker/compose.yaml down

--- a/docs/LOAD_TESTING.md
+++ b/docs/LOAD_TESTING.md
@@ -18,7 +18,7 @@ docker compose up redis llm-sidecar
 Wait until the API is available at `http://localhost:8000`.
 
 ## Running the load test
-From the repository root, execute:
+The default script `k6_sidecar_load.js` exercises the `/generate` and `/metrics` endpoints. From the repository root, execute:
 
 ```bash
 k6 run scripts/load/k6_sidecar_load.js
@@ -37,6 +37,22 @@ Set `OSIRIS_URL` to target a different base URL:
 ```bash
 OSIRIS_URL=http://localhost:8000 k6 run scripts/load/k6_sidecar_load.js
 ```
+
+### Additional scenarios
+
+Two more scripts cover read‑heavy and write‑heavy patterns:
+
+* `k6_read_heavy.js` performs repeated `GET /health` and `GET /metrics` requests.
+* `k6_propose_trade.js` posts prompts from `prompts.json` to `/propose_trade_adjustments/`.
+
+Run them in the same way, for example:
+
+```bash
+k6 run scripts/load/k6_read_heavy.js
+k6 run scripts/load/k6_propose_trade.js
+```
+
+The `prompts.json` file can be edited to supply custom test inputs.
 
 ## Stopping services
 Press `Ctrl+C` to stop k6 when done. Shut down the stack with:

--- a/scripts/load/k6_propose_trade.js
+++ b/scripts/load/k6_propose_trade.js
@@ -1,0 +1,32 @@
+import http from 'k6/http';
+import { sleep, check } from 'k6';
+import { SharedArray } from 'k6/data';
+import { randomItem } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+
+const prompts = new SharedArray('prompts', () => JSON.parse(open('prompts.json')));
+
+export const options = {
+  stages: [
+    { duration: '5s', target: 3 },
+    { duration: '20s', target: 3 },
+    { duration: '5s', target: 0 },
+  ],
+  summaryTrendStats: ['avg', 'p(95)', 'p(99)', 'min', 'max'],
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    http_req_duration: ['p(95)<1500'],
+  },
+};
+
+const BASE_URL = __ENV.OSIRIS_URL || 'http://localhost:8000';
+
+export default function () {
+  const prompt = randomItem(prompts);
+  const payload = JSON.stringify({ prompt: prompt, max_length: 64 });
+  const params = { headers: { 'Content-Type': 'application/json' } };
+
+  const res = http.post(`${BASE_URL}/propose_trade_adjustments/`, payload, params);
+  check(res, { 'pta status 200': (r) => r.status === 200 });
+
+  sleep(1);
+}

--- a/scripts/load/k6_read_heavy.js
+++ b/scripts/load/k6_read_heavy.js
@@ -1,0 +1,27 @@
+import http from 'k6/http';
+import { sleep, check } from 'k6';
+
+export const options = {
+  stages: [
+    { duration: '5s', target: 5 },
+    { duration: '20s', target: 5 },
+    { duration: '5s', target: 0 },
+  ],
+  summaryTrendStats: ['avg', 'p(95)', 'p(99)', 'min', 'max'],
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    http_req_duration: ['p(95)<500'],
+  },
+};
+
+const BASE_URL = __ENV.OSIRIS_URL || 'http://localhost:8000';
+
+export default function () {
+  const health = http.get(`${BASE_URL}/health`);
+  check(health, { 'health status 200': (r) => r.status === 200 });
+
+  const metrics = http.get(`${BASE_URL}/metrics`);
+  check(metrics, { 'metrics status 200': (r) => r.status === 200 });
+
+  sleep(1);
+}

--- a/scripts/load/prompts.json
+++ b/scripts/load/prompts.json
@@ -1,0 +1,5 @@
+[
+  "Generate a simple trade idea for AAPL",
+  "Provide a short plan for trading BTC",
+  "What's a good strategy for SPY?"
+]


### PR DESCRIPTION
## Summary
- extend load testing docs with new scenarios
- add read-heavy and propose trade k6 scripts
- provide sample prompt data for k6
- wire up a k6 smoke test GitHub action

## Testing
- `pre-commit run --files docs/LOAD_TESTING.md scripts/load/k6_read_heavy.js scripts/load/k6_propose_trade.js scripts/load/prompts.json .github/workflows/k6-smoke.yaml`
- `pytest tests/test_harvest.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6840c4700f8c832fb7f7ca5b08474b41