### PR TITLE
feat: add security scanning

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,55 @@
+name: Security Scans
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  sast:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install Bandit
+        run: pip install bandit
+      - name: Run Bandit
+        run: |
+          bandit -r . -ll -x tests --format json -o bandit-report.json --exit-zero
+      - name: Upload Bandit report
+        uses: actions/upload-artifact@v4
+        with:
+          name: bandit-report
+          path: bandit-report.json
+          if-no-files-found: warn
+          retention-days: 7
+
+  dependency-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install pip-audit
+        run: pip install pip-audit
+      - name: Run pip-audit
+        run: |
+          pip-audit -r requirements.txt -f json -o pip-audit.json || true
+      - name: Upload pip-audit report
+        uses: actions/upload-artifact@v4
+        with:
+          name: pip-audit-report
+          path: pip-audit.json
+          if-no-files-found: warn
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ The console uses Server-Sent Events (SSE) via the `/stream/audio` endpoint, whic
 - **`.github/workflows/ci-audio-smoke.yaml`**: Performs a smoke test on the TTS audio generation by calling `/speak` and verifying the WAV output.
 - **`.github/workflows/e2e-orchestrator.yaml`**: (Assumed from badge) Runs an end-to-end test of the orchestrator loop.
 - **Lint job**: Quick check that runs `actionlint` and `yamllint` on every pull request before Docker builds.
+- **`.github/workflows/security.yaml`**: Runs Bandit and pip-audit to detect vulnerabilities in the codebase and dependencies.
 
 
 Patience Profits!


### PR DESCRIPTION
## Summary
- add a `security.yaml` workflow with Bandit and pip-audit
- document security workflow in README

## Testing
- `pre-commit run --files README.md .github/workflows/security.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6840d1445e40832f964d8916ed798aed