### PR TITLE
Add production example terraform environment

### DIFF
--- a/infra/terraform/environments/README.md
+++ b/infra/terraform/environments/README.md
@@ -2,10 +2,11 @@
 
 This directory contains example Terraform configurations for deploying Osiris using the shared module.
 
-Two sample environments are provided:
+The following sample environments are provided:
 
 - `dev` – a lightweight setup intended for development and testing.
 - `staging` – a configuration that more closely mirrors production settings.
+- `production_example` – demonstrates production-like settings with higher availability and external services.
 
 To deploy an environment, change into the desired directory and run:
 

--- a/infra/terraform/environments/production_example/README.md
+++ b/infra/terraform/environments/production_example/README.md
@@ -1,0 +1,10 @@
+# Osiris "Production-like" Environment
+
+This example demonstrates a more robust configuration using the Osiris Terraform module.
+It showcases higher replica counts, explicit resource limits and the ability to
+consume managed services such as cloud hosted Redis. Secrets are expected to be
+populated by an external system, so none are hard coded here. A sample
+Horizontal Pod Autoscaler is defined and ingress resources can be provided via
+`additional_values`.
+
+Run `terraform init` and `terraform plan` to validate the configuration.

--- a/infra/terraform/environments/production_example/main.tf
+++ b/infra/terraform/environments/production_example/main.tf
@@ -1,0 +1,75 @@
+terraform {
+  required_version = ">= 1.3"
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.11"
+    }
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = var.kubeconfig
+  }
+}
+
+provider "kubernetes" {
+  config_path = var.kubeconfig
+}
+
+module "osiris" {
+  source = "../../modules/osiris_sidecar"
+
+  namespace                     = var.namespace
+  image_tag                     = var.image_tag
+  replica_count                 = var.replica_count
+  llm_sidecar_image_tag         = var.llm_sidecar_image_tag
+  llm_sidecar_replica_count     = var.llm_sidecar_replica_count
+  llm_sidecar_resources         = var.llm_sidecar_resources
+  otel_collector_endpoint       = var.otel_collector_endpoint
+  llm_sidecar_gpu_node_selector = var.llm_sidecar_gpu_node_selector
+  additional_values             = merge({
+    orchestrator = {
+      resources = var.orchestrator_resources
+    }
+    redis = {
+      enabled = false
+    }
+  }, var.additional_values)
+}
+
+resource "kubernetes_horizontal_pod_autoscaler_v2" "orchestrator" {
+  metadata {
+    name      = "${module.osiris.release_name}-orchestrator"
+    namespace = module.osiris.namespace
+  }
+
+  spec {
+    scale_target_ref {
+      api_version = "apps/v1"
+      kind        = "Deployment"
+      name        = "${module.osiris.release_name}-orchestrator"
+    }
+
+    min_replicas = 3
+    max_replicas = 10
+
+    metric {
+      type = "Resource"
+      resource {
+        name = "cpu"
+        target {
+          type                = "Utilization"
+          average_utilization = 70
+        }
+      }
+    }
+  }
+}
+
+

--- a/infra/terraform/environments/production_example/outputs.tf
+++ b/infra/terraform/environments/production_example/outputs.tf
@@ -1,0 +1,11 @@
+output "release_name" {
+  value = module.osiris.release_name
+}
+
+output "namespace" {
+  value = module.osiris.namespace
+}
+
+output "status" {
+  value = module.osiris.status
+}

--- a/infra/terraform/environments/production_example/variables.tf
+++ b/infra/terraform/environments/production_example/variables.tf
@@ -1,0 +1,83 @@
+variable "kubeconfig" {
+  description = "Path to kubeconfig file"
+  type        = string
+  default     = "~/.kube/config"
+}
+
+variable "namespace" {
+  description = "Namespace to deploy Osiris"
+  type        = string
+  default     = "osiris-prod"
+}
+
+variable "image_tag" {
+  description = "Orchestrator image tag"
+  type        = string
+  default     = "v1.0.0"
+}
+
+variable "llm_sidecar_image_tag" {
+  description = "LLM sidecar image tag"
+  type        = string
+  default     = "v1.0.0"
+}
+
+variable "otel_collector_endpoint" {
+  description = "OTEL collector endpoint"
+  type        = string
+  default     = ""
+}
+
+variable "llm_sidecar_gpu_node_selector" {
+  description = "Node selector labels for GPU nodes"
+  type        = map(string)
+  default     = {}
+}
+
+variable "replica_count" {
+  description = "Number of orchestrator replicas"
+  type        = number
+  default     = 3
+}
+
+variable "llm_sidecar_replica_count" {
+  description = "Number of LLM sidecar replicas"
+  type        = number
+  default     = 3
+}
+
+variable "llm_sidecar_resources" {
+  description = "Resource requests and limits for the LLM sidecar"
+  type        = any
+  default = {
+    limits = {
+      cpu    = "2"
+      memory = "4Gi"
+    }
+    requests = {
+      cpu    = "1"
+      memory = "2Gi"
+    }
+  }
+}
+
+variable "orchestrator_resources" {
+  description = "Resource requests and limits for the orchestrator"
+  type        = any
+  default = {
+    limits = {
+      cpu    = "2"
+      memory = "2Gi"
+    }
+    requests = {
+      cpu    = "1"
+      memory = "1Gi"
+    }
+  }
+}
+
+variable "additional_values" {
+  description = "Additional Helm values for advanced configuration"
+  type        = map(any)
+  default     = {}
+}


### PR DESCRIPTION
## Summary
- add `production_example` Terraform environment showing advanced settings
- document new environment in README

## Testing
- `pre-commit` *(passed)*
- `terraform init` *(failed: Forbidden when fetching provider plugins)*

------
https://chatgpt.com/codex/tasks/task_e_6840d157b8c0832f9e6a5e5a4e3d2ade