### PR TITLE
ci(test): integrate CPU watchdog test

### DIFF
--- a/.github/workflows/vram-watchdog-ci.yml
+++ b/.github/workflows/vram-watchdog-ci.yml
@@ -1,0 +1,48 @@
+name: VRAM Watchdog CI Test
+
+on:
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  watchdog-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Osiris Setup
+        uses: ./.github/actions/osiris-setup
+        with:
+          install-requirements: 'false'
+          system-packages: 'docker-compose'
+
+      - name: Copy .env template
+        run: cp .env.template .env
+
+      - name: Start llm-sidecar
+        run: docker compose -f docker/compose.yaml up -d llm-sidecar
+
+      - name: Run VRAM watchdog script in CPU mode
+        run: |
+          mkdir -p ./watchdog_logs
+          CPU_MODE=1 \
+          CPU_THRESHOLD_MIB=1 \
+          CONSECUTIVE_CHECKS_LIMIT=1 \
+          MAX_ITERATIONS=2 \
+          INTERVAL=1 \
+          LOG_FILE=$(pwd)/watchdog_logs/vram_watchdog.log \
+          bash scripts/vram_watchdog.sh
+
+      - name: Upload watchdog log
+        uses: actions/upload-artifact@v4
+        with:
+          name: vram-watchdog-log
+          path: watchdog_logs/vram_watchdog.log
+          if-no-files-found: ignore
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f docker/compose.yaml down
+

--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ This setup will start the simulator feeding data into Redis, and the orchestrato
 * polls `nvidia-smi` every 60 s;
 * if usage > **10.5 GB** for 3 consecutive reads it restarts `llm-sidecar`.
 
+When `CPU_MODE=1` the script reads host memory usage instead of VRAM. This
+allows basic logic testing in CI without a GPU. Use `MAX_ITERATIONS` to limit
+loops for short runs.
+
 ---
 
 ## API Endpoints


### PR DESCRIPTION
## Summary
- adjust `vram_watchdog.sh` to support CPU mode and finite loops
- document CPU mode in README
- add workflow to run the watchdog logic in CI

## Testing
- `pre-commit run --files scripts/vram_watchdog.sh README.md .github/workflows/vram-watchdog-ci.yml`
- `pytest tests/test_harvest.py` *(fails: ModuleNotFoundError: No module named 'lancedb')*

------
https://chatgpt.com/codex/tasks/task_e_6840d0e71f14832fbd3bafefce39a475