### PR TITLE
chore(quality): polish codebase and document debt

### DIFF
--- a/.github/workflows/chaos-redis.yaml
+++ b/.github/workflows/chaos-redis.yaml
@@ -13,7 +13,6 @@ jobs:
       CHAOS_MODE: "1"
       PYTHONUNBUFFERED: "1"
       LANCEDB_URI: "./lancedb_data"
-      REDIS_CONTAINER_ID: ${{ job.services.redis.id }}
 
     services:
       redis:
@@ -81,6 +80,9 @@ jobs:
           done
           echo "Redis is up."
           sleep 5
+
+      - name: Export Redis container ID
+        run: echo "REDIS_CONTAINER_ID=${{ job.services.redis.id }}" >> "$GITHUB_ENV"
 
       - name: Run LanceDB migrations
         run: docker compose -f docker/compose.yaml exec -T llm-sidecar python /app/scripts/migrate_lancedb_20250604.py

--- a/dgm_kernel/meta_loop.py
+++ b/dgm_kernel/meta_loop.py
@@ -1,8 +1,6 @@
 # dgm_kernel/meta_loop.py
 """
 Darwin Gödel Machine – self-improvement meta-loop (async capable)
-
-TODOs are marked ▼
 """
 
 from __future__ import annotations
@@ -86,7 +84,8 @@ async def generate_patch(
 ) -> dict | None:  # Return type updated to include None
     """
     Emit a JSON patch using an LLM or search routine.
-    ▼ TODO: Replace with actual patch generation logic.
+    TODO(https://github.com/82edge/osiris/issues/99):
+        Replace with full patch generation logic.
     """
     return draft_patch(traces)
 

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -1,0 +1,14 @@
+# Technical Debt Overview
+
+This document captures areas of the codebase that may require future refactoring or cleanup.
+
+## Orchestrator Configuration
+- Some endpoints like the Phi-3 generation service and event bus Redis URL were previously hard-coded. They now fall back to environment variables (`PHI3_API_URL` and `EVENT_BUS_REDIS_URL`) but could benefit from a central configuration system.
+
+## dgm_kernel Patch Generation
+- `dgm_kernel/meta_loop.py` still relies on a placeholder patch generation function. See TODO at line 87 referencing [issue #99](https://github.com/82edge/osiris/issues/99).
+
+## Broken Symlinks
+- Files under `osiris/scripts/` are symbolic links ending with a trailing newline in the target path, making them unusable. This should be corrected by recreating the symlinks without newline characters.
+
+

--- a/scripts/chaos_disk_fill.py
+++ b/scripts/chaos_disk_fill.py
@@ -16,17 +16,30 @@ def run(cmd: str) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Fill disk space inside a container")
-    parser.add_argument("--container", default=os.environ.get("DISK_CHAOS_CONTAINER", "llm-sidecar"))
-    parser.add_argument("--path", default=os.environ.get("DISK_CHAOS_PATH", "/app/lancedb_data"))
-    parser.add_argument("--size", type=int, default=int(os.environ.get("DISK_CHAOS_SIZE_MB", "500")), help="Size in MB")
-    parser.add_argument("--duration", type=int, default=int(os.environ.get("DISK_CHAOS_DURATION", "30")))
+    parser.add_argument(
+        "--container", default=os.environ.get("DISK_CHAOS_CONTAINER", "llm-sidecar")
+    )
+    parser.add_argument(
+        "--path", default=os.environ.get("DISK_CHAOS_PATH", "/app/lancedb_data")
+    )
+    parser.add_argument(
+        "--size",
+        type=int,
+        default=int(os.environ.get("DISK_CHAOS_SIZE_MB", "500")),
+        help="Size in MB",
+    )
+    parser.add_argument(
+        "--duration", type=int, default=int(os.environ.get("DISK_CHAOS_DURATION", "30"))
+    )
     args = parser.parse_args()
 
     file_path = os.path.join(args.path, "diskfill.tmp")
     log(
         f"Filling {args.size}MB at {file_path} in {args.container} for {args.duration}s"
     )
-    run(f"docker exec {args.container} dd if=/dev/zero of={file_path} bs=1M count={args.size} || true")
+    run(
+        f"docker exec {args.container} dd if=/dev/zero of={file_path} bs=1M count={args.size} || true"
+    )
     time.sleep(args.duration)
     run(f"docker exec {args.container} rm -f {file_path} || true")
     log("Disk fill chaos complete")

--- a/scripts/chaos_network_impair.py
+++ b/scripts/chaos_network_impair.py
@@ -28,10 +28,18 @@ def ensure_tc(container: str) -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Introduce network latency and packet loss")
-    parser.add_argument("--container", default=os.environ.get("NET_CHAOS_CONTAINER", "llm-sidecar"))
-    parser.add_argument("--delay-ms", default=os.environ.get("NET_CHAOS_DELAY_MS", "200"))
-    parser.add_argument("--loss", default=os.environ.get("NET_CHAOS_LOSS_PERCENT", "10"))
+    parser = argparse.ArgumentParser(
+        description="Introduce network latency and packet loss"
+    )
+    parser.add_argument(
+        "--container", default=os.environ.get("NET_CHAOS_CONTAINER", "llm-sidecar")
+    )
+    parser.add_argument(
+        "--delay-ms", default=os.environ.get("NET_CHAOS_DELAY_MS", "200")
+    )
+    parser.add_argument(
+        "--loss", default=os.environ.get("NET_CHAOS_LOSS_PERCENT", "10")
+    )
     parser.add_argument(
         "--duration", type=int, default=int(os.environ.get("NET_CHAOS_DURATION", "30"))
     )

--- a/scripts/chaos_report.py
+++ b/scripts/chaos_report.py
@@ -6,13 +6,17 @@ import lancedb
 
 
 def container_running(name: str) -> bool:
-    result = subprocess.run([
-        "docker",
-        "inspect",
-        "-f",
-        "{{.State.Running}}",
-        name,
-    ], capture_output=True, text=True)
+    result = subprocess.run(
+        [
+            "docker",
+            "inspect",
+            "-f",
+            "{{.State.Running}}",
+            name,
+        ],
+        capture_output=True,
+        text=True,
+    )
     return result.stdout.strip() == "true"
 
 

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -6,48 +6,54 @@ import sys
 from types import ModuleType
 from fastapi.openapi.utils import get_openapi
 
-mock_loader = ModuleType('llm_sidecar.loader')
+mock_loader = ModuleType("llm_sidecar.loader")
 mock_loader.load_hermes_model = lambda: None
 mock_loader.load_phi3_model = lambda: None
 mock_loader.get_hermes_model_and_tokenizer = lambda: (None, None)
 mock_loader.get_phi3_model_and_tokenizer = lambda: (None, None)
-mock_loader.MICRO_LLM_MODEL_PATH = ''
+mock_loader.MICRO_LLM_MODEL_PATH = ""
 mock_loader.phi3_adapter_date = None
-mock_tts = ModuleType('llm_sidecar.tts')
+mock_tts = ModuleType("llm_sidecar.tts")
 mock_tts.ChatterboxTTS = lambda *a, **k: None
-mock_torch = ModuleType('torch')
-mock_torch.cuda = ModuleType('torch.cuda')
+mock_torch = ModuleType("torch")
+mock_torch.cuda = ModuleType("torch.cuda")
 mock_torch.cuda.is_available = lambda: False
-mock_outlines = ModuleType('outlines')
+mock_outlines = ModuleType("outlines")
 mock_outlines.generate = lambda *a, **k: None
-mock_lancedb = ModuleType('lancedb')
-mock_lancedb.pydantic = ModuleType('lancedb.pydantic')
+mock_lancedb = ModuleType("lancedb")
+mock_lancedb.pydantic = ModuleType("lancedb.pydantic")
 mock_lancedb.pydantic.LanceModel = object
-mock_lancedb.connect = lambda *a, **k: type('DB', (), {'open_table': lambda *a, **k: None})()
-mock_redis = ModuleType('redis')
-mock_redis.asyncio = ModuleType('redis.asyncio')
-mock_redis.asyncio.client = ModuleType('redis.asyncio.client')
+mock_lancedb.connect = lambda *a, **k: type(
+    "DB", (), {"open_table": lambda *a, **k: None}
+)()
+mock_redis = ModuleType("redis")
+mock_redis.asyncio = ModuleType("redis.asyncio")
+mock_redis.asyncio.client = ModuleType("redis.asyncio.client")
 mock_redis.asyncio.client.PubSub = object
-mock_redis.exceptions = ModuleType('redis.exceptions')
+mock_redis.exceptions = ModuleType("redis.exceptions")
 mock_redis.exceptions.RedisError = Exception
 mock_redis.asyncio.from_url = lambda *a, **k: None
 
-with patch.dict(sys.modules, {
-    'llm_sidecar.loader': mock_loader,
-    'llm_sidecar.tts': mock_tts,
-    'torch': mock_torch,
-    'lancedb': mock_lancedb,
-    'lancedb.pydantic': mock_lancedb.pydantic,
-    'outlines': mock_outlines,
-    'redis.asyncio': mock_redis.asyncio,
-    'redis.asyncio.client': mock_redis.asyncio.client,
-    'redis.exceptions': mock_redis.exceptions,
-    'redis': mock_redis,
-}):
+with patch.dict(
+    sys.modules,
+    {
+        "llm_sidecar.loader": mock_loader,
+        "llm_sidecar.tts": mock_tts,
+        "torch": mock_torch,
+        "lancedb": mock_lancedb,
+        "lancedb.pydantic": mock_lancedb.pydantic,
+        "outlines": mock_outlines,
+        "redis.asyncio": mock_redis.asyncio,
+        "redis.asyncio.client": mock_redis.asyncio.client,
+        "redis.exceptions": mock_redis.exceptions,
+        "redis": mock_redis,
+    },
+):
     import importlib
-    dummy_llm = ModuleType('osiris.llm_sidecar')
-    sys.modules['osiris.llm_sidecar'] = dummy_llm
-    server = importlib.import_module('osiris.server')
+
+    dummy_llm = ModuleType("osiris.llm_sidecar")
+    sys.modules["osiris.llm_sidecar"] = dummy_llm
+    server = importlib.import_module("osiris.server")
 
 schema = get_openapi(
     title=server.app.title,

--- a/tests/dgm_kernel/test_meta_loop.py
+++ b/tests/dgm_kernel/test_meta_loop.py
@@ -248,8 +248,7 @@ async def test_meta_loop_applies_good_patch(
 
 
 # Test that a negative reward triggers rollback and traces are tagged.
-# TODO: Add test for meta_loop_skips_unproven_patch
-# Similar, but _prove_patch returns False. Assert _apply_patch is not called.
+# Similar logic is covered in test_meta_loop_skips_unproven_patch below.
 
 
 @pytest.mark.asyncio
@@ -319,6 +318,7 @@ async def test_meta_loop_rolls_back_bad_patch(
     ]
     assert rb_entries == [{"id": "trace1", "value": 100, "rolled_back": True}]
 
+
 @pytest.mark.asyncio
 @mock.patch("dgm_kernel.meta_loop.generate_patch")
 @mock.patch("dgm_kernel.meta_loop._verify_patch")
@@ -358,7 +358,9 @@ async def test_meta_loop_skips_unproven_patch(
     accepted, _ = await meta_loop._verify_patch(traces, patch_data)
     if accepted:
         if meta_loop._apply_patch(patch_data):
-            _ = sum(meta_loop.proofable_reward(t, patch_data.get("after")) for t in traces)
+            _ = sum(
+                meta_loop.proofable_reward(t, patch_data.get("after")) for t in traces
+            )
 
     mock_apply_patch.assert_not_called()
     mock_reward.assert_not_called()

--- a/tests/mock_orchestrator.py
+++ b/tests/mock_orchestrator.py
@@ -5,21 +5,32 @@ from common.otel_init import init_otel
 from opentelemetry import trace
 
 # Patch heavy dependencies before import
-with patch('osiris_policy.orchestrator.EventBus'), \
-     patch('osiris_policy.orchestrator.log_run'), \
-     patch('osiris_policy.orchestrator.init_advice_table'), \
-     patch('osiris_policy.orchestrator.market_tick_listener', new=AsyncMock()), \
-     patch('osiris_policy.orchestrator.build_graph', return_value=MagicMock(ainvoke=AsyncMock(return_value={}))) as _:
+with (
+    patch("osiris_policy.orchestrator.EventBus"),
+    patch("osiris_policy.orchestrator.log_run"),
+    patch("osiris_policy.orchestrator.init_advice_table"),
+    patch("osiris_policy.orchestrator.market_tick_listener", new=AsyncMock()),
+    patch(
+        "osiris_policy.orchestrator.build_graph",
+        return_value=MagicMock(ainvoke=AsyncMock(return_value={})),
+    ) as _,
+):
     from osiris_policy import orchestrator
 
 # Initialize OTEL and run a span around main_async
 init_otel()
 tracer = trace.get_tracer(__name__)
-args = SimpleNamespace(redis_url="redis://localhost:6379/0", market_channel="market.ticks", ticks_per_proposal=1)
+args = SimpleNamespace(
+    redis_url="redis://localhost:6379/0",
+    market_channel="market.ticks",
+    ticks_per_proposal=1,
+)
+
 
 async def run():
     with tracer.start_as_current_span("orchestrator.run"):
         await orchestrator.main_async(args)
+
 
 if __name__ == "__main__":
     asyncio.run(run())

--- a/tests/mock_sidecar.py
+++ b/tests/mock_sidecar.py
@@ -2,9 +2,11 @@ from unittest.mock import patch, MagicMock, AsyncMock
 import uvicorn
 
 # Patch heavy model loading before importing server
-with patch('llm_sidecar.loader.load_hermes_model'), \
-     patch('llm_sidecar.loader.load_phi3_model'), \
-     patch('llm_sidecar.tts.ChatterboxTTS'):
+with (
+    patch("llm_sidecar.loader.load_hermes_model"),
+    patch("llm_sidecar.loader.load_phi3_model"),
+    patch("llm_sidecar.tts.ChatterboxTTS"),
+):
     import osiris.server as server
 
 # Patch generation helpers to return quickly


### PR DESCRIPTION
## Summary
- run aggressive linting across repo
- fix GitHub Actions lint error and export redis container ID via step
- make orchestrator URLs configurable via env vars
- clean up tests and scripts after lint
- document technical debt items

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError for hypothesis, fakeredis, redis, httpx, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6840d163653c832fb133dff2c3f9573a