### PR TITLE
feat(observability): define latency alert

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -29,6 +29,14 @@ The following alerts are defined:
     *   **Description:** Monitors the GPU VRAM usage. Triggers if the average VRAM usage exceeds 90% for 2 minutes.
     *   **Metric Used (example):** `avg_over_time(dcgm_fb_used_bytes[2m]) / avg_over_time(dcgm_fb_total_bytes[2m]) * 100` (or `dcgm_fb_used_percent`). Ensure your GPU monitoring exposes these DCGM metrics.
 
+*   **VramWatchdogHighUsage**
+    *   **Description:** Raised by the VRAM watchdog container when GPU memory stays above 90% for 2 minutes.
+    *   **Metric Used:** Same as **HighGpuVramUsage** – `dcgm_fb_used_bytes` vs `dcgm_fb_total_bytes`.
+
+*   **HighApiLatency**
+    *   **Description:** Monitors the p95 HTTP request latency. Triggers if the 95th percentile latency exceeds 5 seconds over a 5-minute window.
+    *   **Metric Used:** `histogram_quantile(0.95, sum(rate(http_server_duration_seconds_bucket[5m])) by (le))`
+
 *   **HighLLMErrorRate**
     *   **Description:** Monitors the error rate of LLM requests. Triggers if the error rate exceeds 5% over a 5-minute period.
     *   **Metric Used (placeholder):** `sum(rate(llm_requests_total{status="error"}[5m])) / sum(rate(llm_requests_total[5m])) * 100`

--- a/ops/prometheus/osiris_alerts.yaml
+++ b/ops/prometheus/osiris_alerts.yaml
@@ -63,3 +63,16 @@ spec:
       annotations:
         summary: Redis backlog too high for queue {{ $labels.list_name }}
         description: The Redis list {{ $labels.list_name }} has {{ $value }} jobs, exceeding the threshold of 5000 for 10 minutes.
+
+    - alert: HighApiLatency
+      expr: |
+        histogram_quantile(0.95,
+          sum(rate(http_server_duration_seconds_bucket{job="llm-sidecar"}[5m])) by (le)
+        ) > 5
+      for: 5m
+      labels:
+        severity: warning
+        service: llm-sidecar
+      annotations:
+        summary: High p95 latency on llm-sidecar
+        description: 95th percentile request latency has exceeded 5 seconds for over 5 minutes.


### PR DESCRIPTION
## Summary
- expand Prometheus alert rules with HighApiLatency
- document all alerts in observability guide

## Testing
- `pre-commit run --files ops/prometheus/osiris_alerts.yaml docs/observability.md`
- `pytest tests/test_harvest.py` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pytest tests/test_traces.py` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_6840d14dbc14832fa2cdc1b5252727c8