### PR TITLE
Refactor CI workflows to gate GPU jobs

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - gpu-enabled

--- a/.github/workflows/ci-audio-smoke.yaml
+++ b/.github/workflows/ci-audio-smoke.yaml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   build-and-test-audio:
-    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' ||
+        contains(github.event.pull_request.labels.*.name, 'run-gpu-tests')
+    runs-on: [self-hosted, gpu-enabled]
     timeout-minutes: 6
     env:
       TORCH_VERSION: "2.2.2+cu121"

--- a/.github/workflows/e2e-adapter-swap.yaml
+++ b/.github/workflows/e2e-adapter-swap.yaml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   smoke-test:
-    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' ||
+        contains(github.event.pull_request.labels.*.name, 'run-gpu-tests')
+    runs-on: [self-hosted, gpu-enabled]
     timeout-minutes: 15
     env:
       TORCH_VERSION: "2.2.2+cu121"

--- a/.github/workflows/llm-sidecar-smoke.yml
+++ b/.github/workflows/llm-sidecar-smoke.yml
@@ -10,7 +10,9 @@ on:
 
 jobs:
   smoke-test:
-    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' ||
+        contains(github.event.pull_request.labels.*.name, 'run-gpu-tests')
+    runs-on: [self-hosted, gpu-enabled]
     env:
       TORCH_VERSION: "2.2.2+cu121"
 

--- a/.github/workflows/vram-watchdog-ci.yml
+++ b/.github/workflows/vram-watchdog-ci.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   watchdog-test:
-    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' ||
+        contains(github.event.pull_request.labels.*.name, 'run-gpu-tests')
+    runs-on: [self-hosted, gpu-enabled]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- gate GPU-dependent workflows behind `run-gpu-tests` label and run on self-hosted GPU runners
- configure actionlint to recognize custom runner labels

## Testing
- `pre-commit run --files .github/workflows/ci-audio-smoke.yaml .github/workflows/e2e-adapter-swap.yaml .github/workflows/llm-sidecar-smoke.yml .github/workflows/vram-watchdog-ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_6840d575002c832f86d6d7fa7b1e6a43