### PR TITLE
docs(ops): add operations and troubleshooting guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,7 @@ helm upgrade --install osiris-canary helm/osiris \
 | Links | Links |
 | --- | --- |
 | [Docs](docs/) | [Developer Guide](docs/DEV_GUIDE.md) |
+| [Day 2 Ops](docs/DAY2_OPERATIONS.md) | [Troubleshooting](docs/ADVANCED_TROUBLESHOOTING.md) |
 | [Load Testing](docs/LOAD_TESTING.md) | [Prometheus Alerts](ops/prometheus/alerts.yaml) |
 | [DGM Paper](docs/research/DGM_mapping.md) | [Helm Chart](helm/osiris) |
 

--- a/docs/ADVANCED_TROUBLESHOOTING.md
+++ b/docs/ADVANCED_TROUBLESHOOTING.md
@@ -1,0 +1,25 @@
+# Advanced Troubleshooting
+
+This page lists techniques for diagnosing issues in a production Osiris deployment.
+
+## Common Runtime Issues
+- **Orchestrator not processing ticks**: ensure `market.ticks` events are published to Redis and that the orchestrator container is subscribed. Use `redis-cli monitor` to watch events.
+- **LLM errors**: check the `llm_sidecar` logs for stack traces. Many issues come from missing models or insufficient GPU memory. Lower `MAX_TOKENS` or run on CPU with `DEVICE=cpu` if needed.
+- **Performance degradation**: use the Grafana dashboard to monitor CPU, memory and GPU usage. High latency may indicate the sidecar is overloaded.
+
+## Interpreting Logs
+- Logs are JSON structured. Use `jq` when tailing files or streaming with `docker compose logs -f`.
+- The orchestrator logs workflow IDs and decisions. LanceDB also records each run for later inspection via `scripts/harvest_feedback.py`.
+- Set `LOG_LEVEL=debug` in the service environment to increase verbosity.
+
+## Using the Observability Stack
+- Prometheus scrapes metrics from each service. Import `ops/prometheus/osiris_alerts.yaml` to enable alerts.
+- Traces emitted via OpenTelemetry can be collected with any OTLP-compatible collector. Set `OTEL_EXPORTER_OTLP_ENDPOINT` to your collector URL.
+- The Grafana dashboard (`ops/grafana/osiris_observability.json`) displays latency, GPU usage, Redis depth and error rates. Use the Service/Environment filters at the top to narrow down issues.
+
+## Common Failure Modes
+- **Redis backlog too high**: the orchestrator may be unable to keep up. Scale the orchestrator or sidecar services and investigate slow tasks.
+- **GPU memory exhaustion**: the VRAM watchdog container will restart the sidecar when usage stays above 90%. Consider reducing batch sizes or switching to CPU for low throughput environments.
+- **Missing LanceDB tables**: ensure the `lancedb_data` volume is mounted and writable. The sidecar creates tables on startup if they do not exist.
+
+If problems persist, compare your deployment against the reference `docker/compose.yaml` or Helm chart to ensure all environment variables and volumes are configured correctly.

--- a/docs/DAY2_OPERATIONS.md
+++ b/docs/DAY2_OPERATIONS.md
@@ -1,0 +1,38 @@
+# Day 2 Operations
+
+This guide covers common tasks for maintaining a running Osiris deployment.
+
+## Checking Service Health
+- Use `docker compose ps` or `kubectl get pods` to verify containers are running and healthy.
+- The `/health` endpoint on each service returns `200` when the component is ready.
+- Stream logs with `docker compose logs -f <service>` or `kubectl logs -f <pod>` to diagnose issues.
+
+## Monitoring Resource Usage
+- Enable the provided Prometheus rules (see `ops/prometheus/osiris_alerts.yaml`).
+- Import the Grafana dashboard at `ops/grafana/osiris_observability.json` to view CPU, memory and GPU metrics.
+- For quick checks, run `docker stats` or use `kubectl top pods` if metrics-server is installed.
+
+## Backup and Restore Procedures
+### LanceDB
+- Data is stored under `/app/lancedb_data` in the `llm-sidecar` container.
+- Mount this path as a persistent volume to keep history between restarts.
+- Periodically copy the directory to durable storage (e.g., S3) and restore it by mounting the saved files.
+
+### Redis
+- The default Docker setup runs Redis with ephemeral storage. For persistence use a volume or enable RDB/AOF in a custom configuration.
+- To back up, copy the `dump.rdb` or `appendonly.aof` files from the Redis data directory.
+
+### Fine‑tuned Adapters
+- If you run `scripts/nightly_qlora.sh` or `scripts/run_qlora.py`, save the adapters written to the `--output_dir`.
+- Store them in version control or external storage and mount them when starting the sidecar.
+
+## Scaling Considerations
+- The `llm_sidecar` service can be scaled horizontally. When using Docker Compose increase `--scale llm-sidecar=<N>`.
+- For Kubernetes, adjust `replicaCount` in `helm/osiris/values.yaml` or enable the `autoscaling` section.
+- Ensure Redis and LanceDB have sufficient resources before scaling the orchestrator or sidecars.
+
+## Upgrading Osiris
+1. Pull the latest container images or build them from the updated repository.
+2. Apply database migrations if any are included.
+3. Restart the services one by one, checking `/health` after each restart.
+4. Re-import the Grafana dashboard if metrics or panels changed.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,8 @@ docs_dir: docs
 nav:
   - Home: index.html
   - API: openapi.md
+  - Day 2 Ops: DAY2_OPERATIONS.md
+  - Troubleshooting: ADVANCED_TROUBLESHOOTING.md
 plugins:
   - search
   - swagger-ui-tag


### PR DESCRIPTION
## Summary
- add Day 2 Operations guide
- document advanced troubleshooting steps
- link new docs from README and mkdocs navigation

## Testing
- `pre-commit run --files README.md docs/DAY2_OPERATIONS.md docs/ADVANCED_TROUBLESHOOTING.md mkdocs.yml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6840d59f6e24832f98a5fa4c2ac72ad1