### PR TITLE
feat(security): add Kubernetes NetworkPolicies

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,21 @@ llmSidecar:
       nvidia.com/gpu: 1
 ```
 
+### Network Policies
+
+The Helm chart ships with optional `NetworkPolicy` resources. They default to
+disabled since some clusters may not include a network policy controller. Enable
+them with:
+
+```bash
+helm upgrade --install osiris helm/osiris \
+  --set networkPolicy.enabled=true
+```
+
+When enabled, ingress and egress traffic between the orchestrator,
+`llm_sidecar`, Redis and LanceDB is restricted to the minimal paths required for
+the application to function.
+
 ### Canary Deployment
 
 Use `helm/osiris/values-canary.yaml` to deploy a canary release. This file

--- a/helm/osiris/Chart.yaml
+++ b/helm/osiris/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/helm/osiris/templates/lancedb-networkpolicy.yaml
+++ b/helm/osiris/templates/lancedb-networkpolicy.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.networkPolicy.enabled .Values.networkPolicy.lancedb.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "osiris.fullname" . }}-lancedb
+  labels:
+    {{- include "osiris.labels" . | nindent 4 }}
+    app.kubernetes.io/component: lancedb
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: lancedb
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "osiris.selectorLabels" . | nindent 12 }}
+              app.kubernetes.io/component: orchestrator
+      ports:
+        - protocol: TCP
+          port: {{ .Values.lancedb.service.port }}
+  egress: []
+{{- end }}

--- a/helm/osiris/templates/llm-sidecar-networkpolicy.yaml
+++ b/helm/osiris/templates/llm-sidecar-networkpolicy.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.networkPolicy.enabled .Values.networkPolicy.llmSidecar.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "osiris.fullname" . }}-llm-sidecar
+  labels:
+    {{- include "osiris.labels" . | nindent 4 }}
+    app.kubernetes.io/component: llm-sidecar
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "osiris.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: llm-sidecar
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "osiris.selectorLabels" . | nindent 12 }}
+              app.kubernetes.io/component: orchestrator
+      ports:
+        - protocol: TCP
+          port: {{ .Values.llmSidecar.service.port }}
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "osiris.selectorLabels" . | nindent 12 }}
+              app.kubernetes.io/component: redis
+      ports:
+        - protocol: TCP
+          port: {{ .Values.redis.service.port }}
+{{- end }}

--- a/helm/osiris/templates/orchestrator-networkpolicy.yaml
+++ b/helm/osiris/templates/orchestrator-networkpolicy.yaml
@@ -1,0 +1,46 @@
+{{- if and .Values.networkPolicy.enabled .Values.networkPolicy.orchestrator.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "osiris.fullname" . }}-orchestrator
+  labels:
+    {{- include "osiris.labels" . | nindent 4 }}
+    app.kubernetes.io/component: orchestrator
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "osiris.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: orchestrator
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        {{- if .Values.networkPolicy.ingressControllerLabels }}
+        - podSelector:
+            matchLabels:
+              {{- range $key, $value := .Values.networkPolicy.ingressControllerLabels }}
+              {{ $key }}: {{ $value | quote }}
+              {{- end }}
+        {{- else }}
+        - {}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.orchestrator.service.port }}
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "osiris.selectorLabels" . | nindent 12 }}
+              app.kubernetes.io/component: llm-sidecar
+        - podSelector:
+            matchLabels:
+              {{- include "osiris.selectorLabels" . | nindent 12 }}
+              app.kubernetes.io/component: redis
+      ports:
+        - protocol: TCP
+          port: {{ .Values.llmSidecar.service.port }}
+        - protocol: TCP
+          port: {{ .Values.redis.service.port }}
+{{- end }}

--- a/helm/osiris/templates/redis-networkpolicy.yaml
+++ b/helm/osiris/templates/redis-networkpolicy.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.networkPolicy.enabled .Values.networkPolicy.redis.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "osiris.fullname" . }}-redis
+  labels:
+    {{- include "osiris.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "osiris.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "osiris.selectorLabels" . | nindent 12 }}
+              app.kubernetes.io/component: orchestrator
+        - podSelector:
+            matchLabels:
+              {{- include "osiris.selectorLabels" . | nindent 12 }}
+              app.kubernetes.io/component: llm-sidecar
+      ports:
+        - protocol: TCP
+          port: {{ .Values.redis.service.port }}
+  egress: []
+{{- end }}

--- a/helm/osiris/values.yaml
+++ b/helm/osiris/values.yaml
@@ -199,3 +199,24 @@ avatar:
   #     nvidia.com/gpu: 1 # Requesting 1 GPU
   replicaCount: 1
   config: {} # Placeholder for avatar-specific configurations
+
+# LanceDB service values
+lancedb:
+  enabled: false
+  service:
+    type: ClusterIP
+    port: 8100
+
+# Network policy configuration
+networkPolicy:
+  enabled: false
+  ingressControllerLabels: {}
+  orchestrator:
+    enabled: true
+  llmSidecar:
+    enabled: true
+  redis:
+    enabled: true
+  lancedb:
+    enabled: false
+


### PR DESCRIPTION
## Summary
- add Kubernetes NetworkPolicy templates for orchestrator, llm sidecar, redis and LanceDB
- make policies optional via `values.yaml`
- bump chart patch version
- document enabling the policies in README

## Testing
- `make format-check` *(fails: ruff E902 cache key errors)*
- `make lint-check` *(fails: ruff execution error)*

------
https://chatgpt.com/codex/tasks/task_e_6840d59433fc832fb839d8a7de330930