### PR TITLE
Audit secrets handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Ignore local environment files and secrets
+.env
+*.env
+configs/env/*.env
+# other typical ignore patterns
+__pycache__/
+*.py[cod]
+.DS_Store
+

--- a/configs/env/dev.env
+++ b/configs/env/dev.env
@@ -1,2 +1,4 @@
-POLYGON_API_KEY=KfHpGT1yr8iQ0Yq6SOUwHdG36ed7aw68
+# Example placeholder key. Replace with your real key in a local `.env` file
+# that is excluded from version control.
+POLYGON_API_KEY=CHANGEME
 REDIS_PASS=

--- a/docs/DEV_GUIDE.md
+++ b/docs/DEV_GUIDE.md
@@ -309,7 +309,10 @@ Before each release we run a bug bash where all failing tests must be addressed.
 You can run `docker compose -f docker/compose.yaml exec llm-sidecar pytest` to execute tests inside the container environment. This mirrors the CI build closely.
 
 ## Credentials
-Sensitive keys should be loaded from the environment only. Avoid committing them to git history. GitHub secrets and local `.env` files keep them isolated from code.
+Sensitive keys should be loaded from the environment only. Avoid committing them
+to git history. A `.gitignore` file now excludes `.env` and other secret files by
+default. Copy `.env.template` to `.env` for local use and store real credentials
+there. See [Secrets Management Review](SECURITY_SECRETS.md) for hardening tips.
 
 ## Long-running tasks
 For lengthy simulations or training loops, consider running inside `tmux` or `screen` so the session survives SSH disconnects. Logs can be tailed in another window while the job runs.

--- a/docs/SECURITY_SECRETS.md
+++ b/docs/SECURITY_SECRETS.md
@@ -1,0 +1,42 @@
+# Secrets Management Review
+
+This document summarizes how secrets are handled in the Osiris project and lists
+recommended improvements.
+
+## Current State
+
+* Local development uses environment files (`.env`) copied from `.env.template`.
+* A sample environment file exists at `configs/env/dev.env` which previously
+  included a real looking `POLYGON_API_KEY`.
+* CI/CD workflows reference GitHub secrets for publishing images and docs.
+* Docker and Kubernetes manifests rely on environment variables for injecting
+  credentials. Examples include the `HF_TOKEN` build argument in the Dockerfile
+  and placeholders in `docker/docker-compose.cloud.yaml`.
+
+## Issues Identified
+
+* `configs/env/dev.env` contained a hard coded API key. Even if the key was not
+  active, keeping it in version control risks accidental exposure.
+* The repository lacked a `.gitignore`, increasing the chance of committing
+  local `.env` files containing credentials.
+
+## Hardening Steps
+
+1. Replaced the `POLYGON_API_KEY` value in `configs/env/dev.env` with a placeholder
+   and documented that real values belong in untracked `.env` files.
+2. Added a `.gitignore` that excludes common secret locations such as `.env`
+   files and the `configs/env` directory.
+3. Updated developer documentation to highlight best practices for handling
+   secrets and to reference this guide.
+
+## Recommendations
+
+* Use a secrets manager (e.g. AWS Secrets Manager or HashiCorp Vault) for
+  production deployments. Mount secrets as files or inject them as environment
+  variables at runtime.
+* Rotate credentials regularly and restrict access based on the principle of
+  least privilege.
+* Avoid storing sensitive data in Docker images or source control. Use build
+  arguments or runtime environment variables instead.
+
+


### PR DESCRIPTION
## Summary
- replace hard-coded API key with placeholder
- ignore env files in `.gitignore`
- document secrets management best practices and add a security report
- clarify credential handling in developer guide

## Testing
- `pre-commit run --files configs/env/dev.env .gitignore docs/SECURITY_SECRETS.md docs/DEV_GUIDE.md`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6840d7d0703c832fa19f44235f7a64a0