### PR TITLE
Add ci-lock target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for LLM Sidecar
 
-.PHONY: rebuild logs
+.PHONY: rebuild logs ci-lock
 
 # Default service for logs if not specified
 SVC ?= llm-sidecar
@@ -10,6 +10,10 @@ rebuild:
 
 logs:
 	@docker compose logs -f $(SVC)
+
+ci-lock:
+	poetry lock --check
+	docker compose config --quiet
 
 # Example usage:
 # make rebuild


### PR DESCRIPTION
## Summary
- run `poetry lock --check` and `docker compose config --quiet`
- document the new Make target

## Testing
- `make ci-lock` *(fails: pyproject missing)*
- `pytest tests/test_harvest.py` *(fails: ModuleNotFoundError: No module named 'lancedb')*

------
https://chatgpt.com/codex/tasks/task_e_683fde8c36c4832fbeedf974b9728c09