### PR TITLE
docs: add production db strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,8 @@ helm upgrade --install osiris-canary helm/osiris \
 | [Docs](docs/) | [Developer Guide](docs/DEV_GUIDE.md) |
 | [Day 2 Ops](docs/DAY2_OPERATIONS.md) | [Troubleshooting](docs/ADVANCED_TROUBLESHOOTING.md) |
 | [Load Testing](docs/LOAD_TESTING.md) | [Prometheus Alerts](ops/prometheus/alerts.yaml) |
-| [DGM Paper](docs/research/DGM_mapping.md) | [Helm Chart](helm/osiris) |
+| [Production DB Strategy](docs/PROD_DB_STRATEGY.md) | [Helm Chart](helm/osiris) |
+| [DGM Paper](docs/research/DGM_mapping.md) | [Observability](docs/observability.md) |
 
 [ci-badge]: https://github.com/OWNER/REPO/actions/workflows/ci.yaml/badge.svg
 [ci]: https://github.com/OWNER/REPO/actions/workflows/ci.yaml

--- a/docs/DAY2_OPERATIONS.md
+++ b/docs/DAY2_OPERATIONS.md
@@ -16,11 +16,11 @@ This guide covers common tasks for maintaining a running Osiris deployment.
 ### LanceDB
 - Data is stored under `/app/lancedb_data` in the `llm-sidecar` container.
 - Mount this path as a persistent volume to keep history between restarts.
-- Periodically copy the directory to durable storage (e.g., S3) and restore it by mounting the saved files.
+- Periodically copy the directory to durable storage (e.g., S3) and restore it by mounting the saved files. See [Production Data Strategy](PROD_DB_STRATEGY.md) for high availability options and an example Terraform module that syncs data to S3.
 
 ### Redis
 - The default Docker setup runs Redis with ephemeral storage. For persistence use a volume or enable RDB/AOF in a custom configuration.
-- To back up, copy the `dump.rdb` or `appendonly.aof` files from the Redis data directory.
+- To back up, copy the `dump.rdb` or `appendonly.aof` files from the Redis data directory. Additional HA guidance is available in [Production Data Strategy](PROD_DB_STRATEGY.md).
 
 ### Fine‑tuned Adapters
 - If you run `scripts/nightly_qlora.sh` or `scripts/run_qlora.py`, save the adapters written to the `--output_dir`.

--- a/docs/PROD_DB_STRATEGY.md
+++ b/docs/PROD_DB_STRATEGY.md
@@ -1,0 +1,46 @@
+# Production Data Strategy: LanceDB & Redis
+
+This document describes how to operate Osiris database components in a production
+environment. LanceDB is used by the `llm_sidecar` to store proposal logs, while
+Redis backs the tick bus and can be used for caching or messaging.
+
+## LanceDB High Availability
+LanceDB does not currently provide built‑in clustering. Treat it similar to a
+single‑node database and run it on resilient storage:
+
+- Deploy the LanceDB container as a **StatefulSet** with a PersistentVolume
+  backed by a highly available storage class (e.g. AWS EBS with replication or
+  an NFS/EFS share).
+- Only one instance should write to the dataset. If multiple replicas are
+  required, run an active/passive setup with a readiness probe so only the leader
+  receives traffic.
+- Store the underlying data on an object store or shared filesystem when
+  possible so a standby node can mount the same files if a failover occurs.
+
+## Redis High Availability
+For production clusters use a Redis deployment that provides automatic failover.
+Common options include:
+
+- **Redis Sentinel** – a primary/replica setup with sentinels to handle
+  promotion. Charts like `bitnami/redis` support this via `architecture=replication`.
+- **Redis Cluster** – shards data across multiple nodes. Use the Bitnami chart or
+  an operator such as `spotahome/redis-operator` to manage the cluster.
+- Always enable persistence (RDB or AOF) and use PersistentVolumes for each pod.
+
+## LanceDB Backup & Recovery
+- The LanceDB dataset lives at `/app/lancedb_data` in the sidecar container.
+- Schedule a `CronJob` or external task to run `aws s3 sync` (or `rclone`) from
+  this directory to durable object storage. The provided Terraform module under
+  `infra/terraform/s3_lancedb_backup` is an example using ECS Fargate.
+- To restore, copy the backup files back into the volume before starting the
+  sidecar or attach the object store path if LanceDB supports it.
+
+## Redis Backup & Recovery
+- If persistence is enabled, trigger a snapshot with `redis-cli BGSAVE` and copy
+  `dump.rdb` (or `appendonly.aof` when using AOF) from the data directory.
+- Automate this with a `CronJob` that archives the file to S3 or another backup
+  location.
+- To recover, place the saved RDB/AOF file in the Redis data directory before
+  starting the server.
+
+For general operational tips see [Day 2 Operations](DAY2_OPERATIONS.md).


### PR DESCRIPTION
## Summary
- document high availability and backup steps for LanceDB and Redis
- reference new guide from Day 2 operations
- link the doc in the README links table

## Testing
- `pre-commit run --files docs/PROD_DB_STRATEGY.md docs/DAY2_OPERATIONS.md README.md`
- `pytest -k 'nothing'` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6840fc212b00832f88be577ab1f427ed