### PR TITLE
Implement timeouts and retries in LLMClient

### DIFF
--- a/osiris/llm_client.py
+++ b/osiris/llm_client.py
@@ -1,0 +1,73 @@
+import logging
+from typing import Any, Dict
+
+import requests
+from tenacity import (
+    Retrying,
+    retry_if_exception_type,
+    retry_if_result,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class LLMClient:
+    """Simple HTTP client for interacting with the LLM sidecar."""
+
+    def __init__(
+        self,
+        base_url: str = "http://localhost:8000",
+        timeout: float = 10.0,
+        retries: int = 3,
+        backoff_factor: float = 0.5,
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.retries = retries
+        self.backoff_factor = backoff_factor
+        self.session = requests.Session()
+
+    def _request_with_retry(
+        self, method: str, endpoint: str, **kwargs
+    ) -> requests.Response:
+        url = f"{self.base_url}{endpoint}"
+
+        def _retryable(resp: requests.Response | None) -> bool:
+            return resp is None or resp.status_code >= 500
+
+        for attempt in Retrying(
+            reraise=True,
+            stop=stop_after_attempt(self.retries),
+            wait=wait_exponential(multiplier=self.backoff_factor),
+            retry=retry_if_exception_type(requests.exceptions.RequestException)
+            | retry_if_result(_retryable),
+        ):
+            with attempt:
+                resp = self.session.request(method, url, timeout=self.timeout, **kwargs)
+                if resp.status_code >= 500:
+                    raise requests.exceptions.HTTPError(
+                        f"Server error: {resp.status_code}", response=resp
+                    )
+                return resp
+
+    def generate(
+        self, model_id: str, prompt: str, max_length: int = 256
+    ) -> Dict[str, Any]:
+        resp = self._request_with_retry(
+            "POST",
+            f"/generate?model_id={model_id}",
+            json={"prompt": prompt, "max_length": max_length},
+        )
+        return resp.json()
+
+    def propose_trade_adjustments(
+        self, prompt: str, max_length: int = 256
+    ) -> Dict[str, Any]:
+        resp = self._request_with_retry(
+            "POST",
+            "/propose_trade_adjustments/",
+            json={"prompt": prompt, "max_length": max_length},
+        )
+        return resp.json()

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,81 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import requests
+
+# Stub heavy optional dependencies
+for name in [
+    "torch",
+    "torchaudio",
+    "chatterbox",
+    "sentry_sdk",
+    "lancedb",
+    "lancedb.pydantic",
+    "transformers",
+    "optimum",
+    "optimum.onnxruntime",
+    "peft",
+]:
+    sys.modules.setdefault(name, MagicMock())
+
+# Stub redis modules
+import types
+
+redis_module = types.ModuleType("redis")
+redis_asyncio = types.ModuleType("redis.asyncio")
+client_mod = types.ModuleType("redis.asyncio.client")
+client_mod.PubSub = type("_DummyPubSub", (), {})
+redis_module.asyncio = redis_asyncio
+sys.modules.setdefault("redis", redis_module)
+sys.modules.setdefault("redis.asyncio", redis_asyncio)
+sys.modules.setdefault("redis.asyncio.client", client_mod)
+exceptions_mod = types.ModuleType("redis.exceptions")
+exceptions_mod.RedisError = Exception
+sys.modules.setdefault("redis.exceptions", exceptions_mod)
+
+# Dynamically import LLMClient without triggering osiris __init__
+import importlib.util
+from pathlib import Path
+
+module_path = Path(__file__).resolve().parents[1] / "osiris" / "llm_client.py"
+spec = importlib.util.spec_from_file_location("osiris.llm_client", module_path)
+llm_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(llm_module)
+LLMClient = llm_module.LLMClient
+
+
+def _mock_response(status_code=200, json_data=None, raise_for_status=None):
+    mock_resp = MagicMock()
+    mock_resp.status_code = status_code
+    mock_resp.json = MagicMock(return_value=json_data)
+    mock_resp.text = str(json_data)
+    if raise_for_status:
+        mock_resp.raise_for_status = MagicMock(side_effect=raise_for_status)
+    else:
+        mock_resp.raise_for_status = MagicMock()
+    return mock_resp
+
+
+class TestLLMClient(unittest.TestCase):
+    def test_retry_on_5xx(self):
+        client = LLMClient(
+            base_url="http://test", timeout=1, retries=2, backoff_factor=0
+        )
+        first = _mock_response(status_code=500)
+        second = _mock_response(status_code=200, json_data={"ok": True})
+        with patch.object(
+            client.session, "request", side_effect=[first, second]
+        ) as mock_request:
+            result = client.generate("phi3", "prompt")
+            self.assertEqual(result, {"ok": True})
+            self.assertEqual(mock_request.call_count, 2)
+            self.assertEqual(mock_request.call_args_list[0][1]["timeout"], 1)
+
+    def test_exceed_retries_raises(self):
+        client = LLMClient(base_url="http://test", retries=2, backoff_factor=0)
+        error_resp = _mock_response(status_code=500)
+        with patch.object(
+            client.session, "request", side_effect=[error_resp, error_resp, error_resp]
+        ):
+            with self.assertRaises(requests.exceptions.HTTPError):
+                client.generate("phi3", "prompt")


### PR DESCRIPTION
## Summary
- implement new `LLMClient` with configurable timeout and retry logic
- add unit tests verifying retry behaviour

## Testing
- `ruff check osiris/llm_client.py tests/test_llm_client.py`
- `black tests/test_llm_client.py osiris/llm_client.py`
- `pytest tests/test_llm_client.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68446d4980c0832fb602b003cc18ef63