### PR TITLE
Implement HITL PR workflow

### DIFF
--- a/dgm_kernel/hitl_pr.py
+++ b/dgm_kernel/hitl_pr.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+import os
+import time
+import difflib
+from github import Github
+
+
+def create_hitl_pr(
+    patch: dict,
+    summary: str,
+    repo_name: str | None = None,
+) -> str:
+    """Create a pull request with the given patch and validation summary.
+
+    Parameters
+    ----------
+    patch : dict
+        Dictionary with keys ``target``, ``before`` and ``after``.
+    summary : str
+        Summary text from the verification process.
+    repo_name : str, optional
+        GitHub repository in the form ``owner/repo``. If omitted,
+        ``GITHUB_REPOSITORY`` environment variable will be used.
+
+    Returns
+    -------
+    str
+        URL of the created pull request.
+    """
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        raise RuntimeError("GITHUB_TOKEN not set")
+
+    repo_name = repo_name or os.environ.get("GITHUB_REPOSITORY")
+    if not repo_name:
+        raise RuntimeError("Repository name not provided")
+
+    gh = Github(token)
+    repo = gh.get_repo(repo_name)
+
+    base_branch = repo.default_branch
+    base = repo.get_branch(base_branch)
+    branch_name = f"hitl-{int(time.time())}"
+    repo.create_git_ref(ref=f"refs/heads/{branch_name}", sha=base.commit.sha)
+
+    file_path = patch["target"]
+    after = patch.get("after", "")
+
+    try:
+        contents = repo.get_contents(file_path, ref=base_branch)
+        repo.update_file(
+            file_path,
+            f"Apply patch via HITL workflow",
+            after,
+            contents.sha,
+            branch=branch_name,
+        )
+    except Exception:
+        repo.create_file(
+            file_path,
+            f"Add {file_path}",
+            after,
+            branch=branch_name,
+        )
+
+    before = patch.get("before", "")
+    diff = "\n".join(
+        difflib.unified_diff(
+            before.splitlines(),
+            after.splitlines(),
+            fromfile="before",
+            tofile="after",
+        )
+    )
+
+    body = (
+        "### Patch Diff\n\n" f"```diff\n{diff}\n```\n" + "\n### Validation Summary\n" + summary
+    )
+
+    pr = repo.create_pull(
+        title=f"HITL Patch {branch_name}",
+        body=body,
+        head=branch_name,
+        base=base_branch,
+    )
+    return pr.html_url

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -3,3 +3,4 @@ black==24.2.0
 ruff==0.4.4
 pip-tools
 pytest
+PyGithub

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -540,3 +540,4 @@ wheel==0.45.1 \
 # satisfied by a package already installed. Consider using the --allow-unsafe flag.
 # pip
 # setuptools
+PyGithub

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -6,3 +6,4 @@ requests>=2
 fakeredis>=2
 hypothesis>=6
 pytest-asyncio>=0.21
+PyGithub

--- a/requirements.in
+++ b/requirements.in
@@ -29,3 +29,4 @@ opentelemetry-sdk
 opentelemetry-exporter-otlp
 opentelemetry-api
 prometheus-fastapi-instrumentator>=6.1
+PyGithub

--- a/requirements.txt
+++ b/requirements.txt
@@ -3159,3 +3159,4 @@ zstandard==0.23.0 \
     --hash=sha256:fd7699e8fd9969f455ef2926221e0233f81a2542921471382e77a9e2f2b57f4b \
     --hash=sha256:fe3b385d996ee0822fd46528d9f0443b880d4d05528fd26a9119a54ec3f91c69
     # via langsmith
+PyGithub

--- a/tests/hitl/test_hitl_pr.py
+++ b/tests/hitl/test_hitl_pr.py
@@ -1,0 +1,34 @@
+import os
+import sys
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from dgm_kernel.hitl_pr import create_hitl_pr
+
+
+@mock.patch("dgm_kernel.hitl_pr.Github")
+def test_create_hitl_pr_makes_pull_request(MockGithub):
+    repo = MockGithub.return_value.get_repo.return_value
+    repo.default_branch = "main"
+    branch = mock.Mock()
+    branch.commit.sha = "abc123"
+    repo.get_branch.return_value = branch
+    repo.get_contents.return_value.sha = "def456"
+
+    patch = {"target": "file.py", "before": "a\n", "after": "a\nb\n"}
+    summary = "All checks passed"
+
+    pr = mock.Mock(html_url="http://example.com/pr/1")
+    repo.create_pull.return_value = pr
+
+    os.environ["GITHUB_TOKEN"] = "x"
+    url = create_hitl_pr(patch, summary, repo_name="owner/repo")
+
+    repo.create_git_ref.assert_called_once()
+    repo.update_file.assert_called_once()
+    repo.create_pull.assert_called_once()
+    assert url == pr.html_url
+    body = repo.create_pull.call_args.kwargs["body"]
+    assert "```diff" in body
+    assert summary in body


### PR DESCRIPTION
## Summary
- add a helper for generating GitHub pull requests from validated patches
- ensure dgm_kernel is a package so tests can import it
- add tests for creating HITL PRs
- include PyGithub in dependency lists

## Testing
- `python -m ruff check dgm_kernel/hitl_pr.py tests/hitl/test_hitl_pr.py dgm_kernel/__init__.py`
- `pytest -q tests/hitl/test_hitl_pr.py`


------
https://chatgpt.com/codex/tasks/task_e_68449774dd50832f9596e10c187cedce