### PR TITLE
Implement trading frictions in sim engine

### DIFF
--- a/docs/DEV_GUIDE.md
+++ b/docs/DEV_GUIDE.md
@@ -144,6 +144,18 @@ Market data CSVs live under `data/`. Use the simulator to feed this data into Re
 python -m sim.engine data/spy_1h.csv --redis_url redis://localhost:6379/0 --speed 10x
 ```
 Customize `--speed` and date range flags to test various scenarios.
+New options allow simulating trading frictions:
+
+```bash
+python -m sim.engine data/spy_1h.csv \
+  --redis_url redis://localhost:6379/0 \
+  --order_channel market.orders \
+  --commission_rate 0.001 \
+  --slippage_impact 0.1
+```
+
+The engine listens for JSON order messages on `--order_channel` and applies the
+configured commission and slippage models when updating the portfolio.
 
 ## GPU troubleshooting
 If the container fails due to VRAM limits, lower `MAX_TOKENS` in the `.env` or switch to CPU mode by setting `DEVICE=cpu`. The `vram_watchdog` service can automatically restart the sidecar when usage exceeds a threshold.

--- a/sim/engine.py
+++ b/sim/engine.py
@@ -1,10 +1,69 @@
 import csv
 import json
-import time
 import asyncio
 import argparse
+from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Optional
+
 from llm_sidecar.event_bus import EventBus, RedisError
+
+
+@dataclass
+class Portfolio:
+    cash: float
+    position: float = 0.0
+    history: list = field(default_factory=list)
+
+    def value(self, market_price: float) -> float:
+        return self.cash + self.position * market_price
+
+
+def calculate_slippage(
+    order_size: float, bar_volume: float, market_price: float, slippage_impact: float
+) -> float:
+    """Return adjusted fill price accounting for slippage."""
+    if bar_volume <= 0:
+        return market_price
+    price_adjustment = (abs(order_size) / bar_volume) * slippage_impact
+    if order_size > 0:
+        return market_price + price_adjustment
+    else:
+        return market_price - price_adjustment
+
+
+def apply_transaction_cost(
+    quantity: float, execution_price: float, commission_rate: float
+) -> float:
+    """Return commission cost for a trade."""
+    return abs(quantity) * execution_price * commission_rate
+
+
+def execute_trade(
+    portfolio: Portfolio,
+    quantity: float,
+    market_price: float,
+    bar_volume: float,
+    commission_rate: float,
+    slippage_impact: float,
+    timestamp: str,
+) -> None:
+    """Execute a trade with slippage and commission."""
+
+    fill_price = calculate_slippage(quantity, bar_volume, market_price, slippage_impact)
+    commission = apply_transaction_cost(quantity, fill_price, commission_rate)
+
+    portfolio.cash -= quantity * fill_price
+    portfolio.cash -= commission
+    portfolio.position += quantity
+    portfolio.history.append(
+        {
+            "timestamp": timestamp,
+            "quantity": quantity,
+            "fill_price": fill_price,
+            "commission": commission,
+        }
+    )
 
 
 async def publish_market_data(
@@ -13,16 +72,49 @@ async def publish_market_data(
     channel_name: str,
     delay_seconds: float = 1.0,
     from_date_str: str = None,
+    order_channel: Optional[str] = "market.orders",
+    commission_rate: float = 0.001,
+    slippage_impact: float = 0.1,
+    starting_cash: float = 100_000.0,
 ):
     """
     Reads OHLCV data from a CSV file and publishes each bar as a JSON dictionary
     to the specified Redis channel.
     """
     event_bus = EventBus(redis_url=redis_url)
+    portfolio = Portfolio(cash=starting_cash)
+    latest_bar = None
+
+    async def handle_order(message: str):
+        nonlocal latest_bar
+        if not latest_bar:
+            print("Order received but no market data available yet. Skipping")
+            return
+        try:
+            order = json.loads(message)
+            qty = float(order.get("quantity", 0))
+        except Exception as exc:
+            print(f"Invalid order message '{message}': {exc}")
+            return
+
+        execute_trade(
+            portfolio,
+            quantity=qty,
+            market_price=latest_bar["close"],
+            bar_volume=latest_bar["volume"],
+            commission_rate=commission_rate,
+            slippage_impact=slippage_impact,
+            timestamp=latest_bar["timestamp"],
+        )
+        print(
+            f"Executed order for {qty} units at last price {latest_bar['close']}. Cash now {portfolio.cash:.2f}"
+        )
 
     try:
         await event_bus.connect()
         print(f"Connected to Redis at {redis_url}")
+        if order_channel:
+            await event_bus.subscribe(order_channel, handle_order)
     except RedisError as e:
         print(f"Error connecting to Redis: {e}")
         return
@@ -135,6 +227,8 @@ async def publish_market_data(
                     if "Adj Close" in row:  # Optional: Add Adj Close if present
                         bar_data["adj_close"] = float(row["Adj Close"])
 
+                    latest_bar = bar_data
+
                     message_json = json.dumps(bar_data)
                     await event_bus.publish(channel_name, message_json)
                     processed_rows += 1
@@ -157,6 +251,11 @@ async def publish_market_data(
                         f"An unexpected error occurred while processing row {row_num + 1}: {e}"
                     )
                     continue
+
+            if latest_bar:
+                final_value = portfolio.value(latest_bar["close"])
+                pnl = final_value - starting_cash
+                print(f"Simulation complete. Final P&L: {pnl:.2f}")
 
     except FileNotFoundError:
         print(f"Error: CSV file not found at {csv_filepath}")
@@ -207,6 +306,31 @@ async def main():
         help="Start publishing data from this date (YYYY-MM-DD).",
     )
 
+    parser.add_argument(
+        "--order_channel",
+        type=str,
+        default="market.orders",
+        help="Redis channel to listen for order messages (default: market.orders)",
+    )
+    parser.add_argument(
+        "--commission_rate",
+        type=float,
+        default=0.001,
+        help="Commission rate applied per trade (default: 0.001)",
+    )
+    parser.add_argument(
+        "--slippage_impact",
+        type=float,
+        default=0.1,
+        help="Slippage impact factor (default: 0.1)",
+    )
+    parser.add_argument(
+        "--starting_cash",
+        type=float,
+        default=100000.0,
+        help="Starting cash balance for the portfolio",
+    )
+
     args = parser.parse_args()
 
     actual_delay = args.delay
@@ -240,6 +364,10 @@ async def main():
         args.channel,
         delay_seconds=actual_delay,
         from_date_str=args.from_date,
+        order_channel=args.order_channel,
+        commission_rate=args.commission_rate,
+        slippage_impact=args.slippage_impact,
+        starting_cash=args.starting_cash,
     )
 
 


### PR DESCRIPTION
## Summary
- extend `sim.engine` with transaction cost and slippage models
- allow configuring commission, slippage impact and starting cash
- document new simulation options in the dev guide

## Testing
- `pytest -q` *(fails: ImportError while importing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68449ac5f36c832f955801a3e33b3c7c