### PR TITLE
Add missing sentry-sdk dependency

### DIFF
--- a/requirements-core.in
+++ b/requirements-core.in
@@ -11,3 +11,4 @@ lancedb
 pandas
 tenacity
 pydantic
+sentry-sdk


### PR DESCRIPTION
## Summary
- include `sentry-sdk` in `requirements-core.in`

## Testing
- `pre-commit run --files requirements-core.in`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_6844b463a744832f882fa8837b391fb3