### PR TITLE
Fix services import path

### DIFF
--- a/tests/test_azr_planner.py
+++ b/tests/test_azr_planner.py
@@ -1,7 +1,11 @@
 from fastapi.testclient import TestClient
-from services.azr_planner.main import app  # Assuming 'app' is directly importable
 
-client = TestClient(app)
+# The AZR planner service lives under `services/azr_planner/main.py`.  Import
+# the FastAPI `app` instance from that module so the tests can exercise the
+# service endpoints.
+from services.azr_planner.main import app as planner_app
+
+client = TestClient(planner_app)
 
 
 def test_plan_alpha_resource_available():


### PR DESCRIPTION
## Summary
- update tests/test_azr_planner.py import path comment and alias

## Testing
- `pytest tests/test_azr_planner.py::test_plan_alpha_resource_available -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6844b474adc8832fa8ab48f58fe8a4cb