### PR TITLE
Fix opentelemetry initialization import

### DIFF
--- a/common/otel_init.py
+++ b/common/otel_init.py
@@ -4,7 +4,6 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 
-
 def init_otel(service_name: str = "osiris-dgm-kernel"):
     """Initializes OpenTelemetry tracing."""
     try:


### PR DESCRIPTION
## Summary
- ensure `common/otel_init.py` matches required OpenTelemetry initialization script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844be176c80832f96f10b0a3e3947f9