### PR TITLE
Fix missing pytest-mock dependency

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -6,3 +6,4 @@ black
 fakeredis
 requests
 hypothesis
+pytest-mock


### PR DESCRIPTION
## Summary
- add pytest-mock to the dev requirements so `mocker` fixture is available

## Testing
- `pytest tests/test_feedback_versioning.py::test_submit_phi3_feedback_stores_version -vv` *(fails: ModuleNotFoundError: No module named 'lancedb')*

------
https://chatgpt.com/codex/tasks/task_e_6844c5f26a70832fbd135447f193fd31