### PR TITLE
Ticket 6.2: skip docker integration tests

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -61,6 +61,7 @@ def run_compose():
     )
 
 
+@pytest.mark.skip(reason="This test requires Docker-in-Docker and is run in a separate CI step")
 @pytest.mark.compose
 def test_metrics_endpoint(run_compose):
     response = requests.get("http://localhost:8000/metrics")
@@ -68,6 +69,7 @@ def test_metrics_endpoint(run_compose):
     assert "python_gc_objects_collected_total" in response.text
 
 
+@pytest.mark.skip(reason="This test requires Docker-in-Docker and is run in a separate CI step")
 @pytest.mark.compose
 def test_health_endpoint(run_compose):
     response = requests.get("http://localhost:8000/health")

--- a/tests/test_orchestrator_e2e.py
+++ b/tests/test_orchestrator_e2e.py
@@ -4,6 +4,8 @@ import time
 import json
 import shutil
 
+import pytest
+
 import requests
 import lancedb
 import redis
@@ -41,6 +43,7 @@ def teardown_module(module):
     shutil.rmtree(DB_DIR, ignore_errors=True)
 
 
+@pytest.mark.skip(reason="This test requires Docker-in-Docker and is run in a separate CI step")
 def test_full_policy_cycle():
     r = redis.Redis(host="localhost", port=6379, decode_responses=True)
     r.ping()

--- a/tests/test_traces.py
+++ b/tests/test_traces.py
@@ -5,6 +5,8 @@ import os
 import re
 from collections import Counter, defaultdict
 
+import pytest
+
 COMPOSE_FILE = os.path.join(os.path.dirname(__file__), "docker-compose.traces.yaml")
 
 
@@ -67,6 +69,7 @@ def teardown_module(module):
     subprocess.run(_compose_cmd("down", "-v"), check=True)
 
 
+@pytest.mark.skip(reason="This test requires Docker-in-Docker and is run in a separate CI step")
 def test_traces_collected():
     requests.post("http://localhost:8000/generate/", json={"prompt": "test"})
     time.sleep(3)
@@ -78,6 +81,7 @@ def test_traces_collected():
     assert counts.get("orchestrator.run", 0) >= 1
 
 
+@pytest.mark.skip(reason="This test requires Docker-in-Docker and is run in a separate CI step")
 def test_trace_correlation_and_parenting():
     requests.post("http://localhost:8000/generate/", json={"prompt": "chain"})
     time.sleep(3)


### PR DESCRIPTION
## Summary
- mark docker-based integration tests to skip in normal runs

## Testing
- `pytest tests/test_metrics.py::test_metrics_endpoint tests/test_metrics.py::test_health_endpoint tests/test_orchestrator_e2e.py::test_full_policy_cycle tests/test_traces.py::test_traces_collected tests/test_traces.py::test_trace_correlation_and_parenting -vv`

------
https://chatgpt.com/codex/tasks/task_e_6844c5fb2df0832fac931f7be3347f22