### PR TITLE
Fix PEFT adapter loading and update tests

### DIFF
--- a/llm_sidecar/loader.py
+++ b/llm_sidecar/loader.py
@@ -4,7 +4,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 from optimum.onnxruntime import ORTModelForCausalLM
 from typing import Optional
 from datetime import datetime
-from peft import PeftModel
+from peft import AutoPeftModel
 
 # Global variables for models and tokenizers
 hermes_model = None
@@ -111,10 +111,10 @@ def load_phi3_model():
             print(f"Loading PEFT adapter for Phi-3 from: {latest_adapter_path}")
             try:
                 # Assuming phi3_model is the base model loaded by ORTModelForCausalLM
-                # and it's compatible with PeftModel.from_pretrained's first argument.
+                # and it's compatible with AutoPeftModel.from_pretrained's expected model argument.
                 # This might need adjustment if ORTModelForCausalLM's output isn't directly usable.
                 # For now, we proceed assuming it is.
-                phi3_model = PeftModel.from_pretrained(phi3_model, latest_adapter_path)
+                phi3_model = AutoPeftModel.from_pretrained(phi3_model, latest_adapter_path)
 
                 # Extract date string from path and format it
                 adapter_dir_name = os.path.basename(

--- a/optimum/onnxruntime/__init__.py
+++ b/optimum/onnxruntime/__init__.py
@@ -1,2 +1,4 @@
 class ORTModelForCausalLM:
-    pass
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        pass

--- a/peft/__init__.py
+++ b/peft/__init__.py
@@ -1,2 +1,10 @@
 class PeftModel:
-    pass
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        pass
+
+
+class AutoPeftModel:
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        pass

--- a/transformers/__init__.py
+++ b/transformers/__init__.py
@@ -1,6 +1,10 @@
 class AutoModelForCausalLM:
-    pass
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        pass
 
 
 class AutoTokenizer:
-    pass
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        pass


### PR DESCRIPTION
## Summary
- support AutoPeftModel loading in `load_phi3_model`
- add placeholder methods in stubs so patching works
- adjust tests for new AutoPeftModel API and patch server globals

## Testing
- `pytest -q tests/test_adapter_hot_swap.py`

------
https://chatgpt.com/codex/tasks/task_e_6844e18df5f8832faa9dd10dca848cc7