### PR TITLE
Fix harvest_feedback test import

### DIFF
--- a/tests/test_harvest.py
+++ b/tests/test_harvest.py
@@ -8,12 +8,18 @@ import lancedb
 from lancedb.pydantic import LanceModel, Vector
 
 # Add project root to sys.path to allow for correct module imports
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
 # Now that the path is set, we can import the script
-from osiris.scripts import harvest_feedback
+# Import the harvest_feedback module directly from the scripts directory
+scripts_dir = os.path.join(project_root, "osiris", "scripts")
+if scripts_dir not in sys.path:
+    sys.path.insert(0, scripts_dir)
+
+import harvest_feedback
+
 
 class TestHarvestFeedback(unittest.TestCase):
 
@@ -22,7 +28,7 @@ class TestHarvestFeedback(unittest.TestCase):
         self.db_path = "/tmp/test_harvest_db"
         self.db = lancedb.connect(self.db_path)
         self.table_name = "phi3_feedback"
-        
+
         # Define a schema that matches what the script might expect
         class Feedback(LanceModel):
             id: str
@@ -32,37 +38,55 @@ class TestHarvestFeedback(unittest.TestCase):
             corrected_proposal: str
             when: str
             user_id: str
+            schema_version: str
 
         try:
-            self.table = self.db.create_table(self.table_name, schema=Feedback, mode="overwrite")
+            self.table = self.db.create_table(
+                self.table_name, schema=Feedback, mode="overwrite"
+            )
         except Exception:
             # Fallback for existing table
             self.table = self.db.open_table(self.table_name)
 
         self.sample_data = [
             {
-                "id": "1", "feedback_type": "rating", "assessment": "good", "proposal": "p1", 
-                "corrected_proposal": "", "when": "2025-06-07T12:00:00Z", "user_id": "user1"
+                "id": "1",
+                "feedback_type": "rating",
+                "assessment": "good",
+                "proposal": "p1",
+                "corrected_proposal": "",
+                "when": "2025-06-07T12:00:00Z",
+                "user_id": "user1",
+                "schema_version": "1.0",
             },
             {
-                "id": "2", "feedback_type": "correction", "assessment": "", "proposal": "p2",
-                "corrected_proposal": '{"action": "BUY"}', "when": "2025-06-07T13:00:00Z", "user_id": "user1"
-            }
+                "id": "2",
+                "feedback_type": "correction",
+                "assessment": "",
+                "proposal": "p2",
+                "corrected_proposal": '{"action": "BUY"}',
+                "when": "2025-06-07T13:00:00Z",
+                "user_id": "user1",
+                "schema_version": "1.0",
+            },
         ]
         if self.table.count_rows() == 0:
-             self.table.add(self.sample_data)
-
+            self.table.add(self.sample_data)
 
     def test_default_extraction(self):
         """Test that the script runs and extracts data."""
         output_jsonl = os.path.join(self.db_path, "output.jsonl")
-        args = ["--db-path", self.db_path, "--output", output_jsonl]
-        
-        with patch('osiris.scripts.harvest_feedback.lancedb.connect') as mock_connect:
+        args = ["--out", output_jsonl]
+
+        with (
+            patch("harvest_feedback.lancedb.connect") as mock_connect,
+            patch("os.path.exists", return_value=True),
+        ):
             mock_connect.return_value = self.db
-            harvest_feedback.main(args)
+            with patch("sys.argv", ["harvest_feedback.py"] + args):
+                harvest_feedback.main()
 
         self.assertTrue(os.path.exists(output_jsonl))
-        with open(output_jsonl, 'r') as f:
+        with open(output_jsonl, "r") as f:
             lines = f.readlines()
             self.assertGreater(len(lines), 0, "Output file should not be empty")


### PR DESCRIPTION
## Summary
- fix module path in harvest feedback test
- normalize sample schema to include `schema_version`
- patch lance db connect and os.path.exists in tests

## Testing
- `pre-commit run --files tests/test_harvest.py`
- `pytest -q tests/test_harvest.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_6844fad1eab4832f8b1a397e6d0e65cb