### PR TITLE
Fix append_feedback to convert dict into Pydantic model

### DIFF
--- a/llm_sidecar/db/__init__.py
+++ b/llm_sidecar/db/__init__.py
@@ -131,8 +131,19 @@ def add_to_table(
 
 
 # --- Specific Data Logging Functions ---
-def append_feedback(feedback_data: Phi3FeedbackSchema) -> None:
-    """Log feedback data."""
+def append_feedback(feedback_data: Phi3FeedbackSchema | Dict[str, Any]) -> None:
+    """Log feedback data.
+
+    Ensure ``feedback_data`` is a :class:`Phi3FeedbackSchema` instance before
+    passing it to :func:`add_to_table`.  This guards against callers providing
+    a plain ``dict`` (as done by the legacy ``submit_phi3_feedback`` helper),
+    which would otherwise cause ``add_to_table`` to access ``dict`` methods on
+    the raw dictionary and fail.
+    """
+
+    if isinstance(feedback_data, dict):
+        feedback_data = Phi3FeedbackSchema(**feedback_data)
+
     add_to_table("phi3_feedback", feedback_data)
 
 


### PR DESCRIPTION
## Summary
- ensure `append_feedback` always passes a `Phi3FeedbackSchema` instance to `add_to_table`
- update documentation in `append_feedback`

## Testing
- `pytest -q tests/test_feedback_versioning.py::test_submit_phi3_feedback_stores_version -vv`

------
https://chatgpt.com/codex/tasks/task_e_6844fe9b6150832f9107006a197da324