### PR TITLE
Fix Pydantic serialization in feedback storage

### DIFF
--- a/llm_sidecar/db/__init__.py
+++ b/llm_sidecar/db/__init__.py
@@ -116,8 +116,10 @@ def add_to_table(
         row = data
     elif hasattr(data, "model_dump"):
         row = data.model_dump(by_alias=True)
-    else:
+    elif hasattr(data, "dict"):
         row = data.dict(by_alias=True)
+    else:
+        row = data
     # Convert UUIDs to strings for storage compatibility
     for key, value in row.items():
         if isinstance(value, uuid.UUID):


### PR DESCRIPTION
## Summary
- ensure `add_to_table` handles both pydantic v1 and v2 models
- use `model_dump()` when available in `submit_phi3_feedback`

## Testing
- `pytest tests/test_feedback_versioning.py::test_submit_phi3_feedback_stores_version -q`

------
https://chatgpt.com/codex/tasks/task_e_6844fee5a01c832fac61fe1bacdc04b0