### PR TITLE
Remove incorrect import from test

### DIFF
--- a/tests/test_feedback_mechanism.py
+++ b/tests/test_feedback_mechanism.py
@@ -16,7 +16,6 @@ from osiris.server import (
     PHI3_FEEDBACK_LOG_FILE,
     PHI3_FEEDBACK_DATA_FILE,
     load_recent_feedback,
-    _generate_phi3_json,
 )
 
 


### PR DESCRIPTION
## Summary
- clean up `tests/test_feedback_mechanism.py` by removing direct import of `_generate_phi3_json`

## Testing
- `pytest tests/test_feedback_mechanism.py -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684503c75d30832fa92b0e2171b917bd