### PR TITLE
Fix init_db to always create hermes_scores table

### DIFF
--- a/llm_sidecar/db/__init__.py
+++ b/llm_sidecar/db/__init__.py
@@ -84,10 +84,10 @@ def init_db() -> None:
         _db = lancedb.connect(DB_ROOT)
 
     for table_name, schema_model in TABLE_SCHEMAS.items():
-        try:
-            table = _db.open_table(table_name)
-        except Exception:
+        if table_name not in _db.table_names():
             table = _db.create_table(table_name, schema=schema_model)
+        else:
+            table = _db.open_table(table_name)
 
         _tables[table_name] = table
     # For compatibility with old global variable names, if needed elsewhere (though should be refactored)


### PR DESCRIPTION
## Summary
- ensure all required tables are created by checking table names before opening

## Testing
- `pytest tests/test_db_bootstrap.py::test_db_initialization_and_operations -vv`

------
https://chatgpt.com/codex/tasks/task_e_6845068f1174832f8c29e7a7822b75ca