### PR TITLE
Fix harvest feedback test imports

### DIFF
--- a/tests/test_harvest.py
+++ b/tests/test_harvest.py
@@ -3,10 +3,9 @@ import sys
 import json
 import unittest
 from pathlib import Path
-from unittest.mock import patch, mock_open
-import pyarrow as pa
+from unittest.mock import patch
 import lancedb
-from lancedb.pydantic import LanceModel, Vector
+from lancedb.pydantic import LanceModel
 
 # Ensure the project root is on the path so test modules can import project code
 PROJECT_ROOT = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary
- ensure `tests/test_harvest.py` can import the `harvest_feedback` script
- drop unused imports

## Testing
- `pytest tests/test_harvest.py::TestHarvestFeedback::test_default_extraction -vv`

------
https://chatgpt.com/codex/tasks/task_e_684507b1b730832fb1d85053d34142d4