### PR TITLE
Fix feedback version test imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,6 @@ select = ["E9"]
 [tool.semantic_release]
 version_variable = "pyproject.toml:version"
 tag_format = "v{version}"
+
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"

--- a/tests/test_feedback_versioning.py
+++ b/tests/test_feedback_versioning.py
@@ -18,7 +18,9 @@ from typing import Optional, Dict, Any, List, Union
 
 # --- Main Application Imports ---
 # Imports the Pydantic model and server function for feedback submission.
-from llm_sidecar.server import FeedbackItem, submit_phi3_feedback
+# Feedback helpers were moved from the deprecated ``llm_sidecar`` package
+# into ``osiris.server`` during refactoring.
+from osiris.server import FeedbackItem, submit_phi3_feedback
 
 # --- Script Imports for Testing ---
 # Imports the main functions from the utility scripts to be tested.


### PR DESCRIPTION
## Summary
- point feedback tests to `osiris.server`
- configure pytest to avoid asyncio warnings

## Testing
- `pytest tests/test_feedback_versioning.py::test_feedback_item_model_defaults_version -vv`

------
https://chatgpt.com/codex/tasks/task_e_684513531944832f82d1f3758f588b89