### PR TITLE
Fix pytest collection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,8 @@ select = ["E9"]
 [tool.semantic_release]
 version_variable = "pyproject.toml:version"
 tag_format = "v{version}"
+
+[tool.pytest.ini_options]
+pythonpath = [
+  "."
+]

--- a/tests/hitl/test_hitl_pr.py
+++ b/tests/hitl/test_hitl_pr.py
@@ -1,8 +1,5 @@
 import os
-import sys
 from unittest import mock
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 from dgm_kernel.hitl_pr import create_hitl_pr
 

--- a/tests/test_adapter_hot_swap.py
+++ b/tests/test_adapter_hot_swap.py
@@ -1,7 +1,11 @@
 import os
 import unittest
 from unittest import mock
+from unittest.mock import MagicMock
 from datetime import datetime
+import sys
+
+sys.modules.setdefault("sentry_sdk", MagicMock())
 
 from fastapi.testclient import TestClient
 

--- a/tests/test_feedback_mechanism.py
+++ b/tests/test_feedback_mechanism.py
@@ -5,6 +5,9 @@ import uuid
 import os
 import asyncio
 from unittest.mock import patch, mock_open, MagicMock, call
+import sys
+
+sys.modules.setdefault("sentry_sdk", MagicMock())
 
 from fastapi.testclient import TestClient
 

--- a/tests/test_feedback_versioning.py
+++ b/tests/test_feedback_versioning.py
@@ -18,7 +18,7 @@ from typing import Optional, Dict, Any, List, Union
 
 # --- Main Application Imports ---
 # Imports the Pydantic model and server function for feedback submission.
-from llm_sidecar.server import FeedbackItem, submit_phi3_feedback
+from osiris.server import FeedbackItem, submit_phi3_feedback
 
 # --- Script Imports for Testing ---
 # Imports the main functions from the utility scripts to be tested.

--- a/tests/test_harvest.py
+++ b/tests/test_harvest.py
@@ -7,17 +7,7 @@ from unittest.mock import patch
 import lancedb
 from lancedb.pydantic import LanceModel
 
-# Ensure the project root is on the path so test modules can import project code
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
-
-# Now that the path is set, ensure the scripts directory is also available
-scripts_dir = PROJECT_ROOT / "osiris" / "scripts"
-if str(scripts_dir) not in sys.path:
-    sys.path.insert(0, str(scripts_dir))
-
-import harvest_feedback
+from osiris.scripts import harvest_feedback
 
 
 class TestHarvestFeedback(unittest.TestCase):
@@ -78,7 +68,7 @@ class TestHarvestFeedback(unittest.TestCase):
         args = ["--out", output_jsonl]
 
         with (
-            patch("harvest_feedback.lancedb.connect") as mock_connect,
+            patch("osiris.scripts.harvest_feedback.lancedb.connect") as mock_connect,
             patch("os.path.exists", return_value=True),
         ):
             mock_connect.return_value = self.db

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -9,6 +9,7 @@ for name in [
     "torchaudio",
     "chatterbox",
     "sentry_sdk",
+    "tenacity",
     "lancedb",
     "lancedb.pydantic",
     "transformers",


### PR DESCRIPTION
## Summary
- fix pythonpath so Pytest finds modules
- drop manual sys.path tweaks in tests
- patch missing dependencies for Sentry and Tenacity
- clean up harvest tests to import from `osiris.scripts`

## Testing
- `pip install -r requirements-tests.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68451576d294832f815813a5a99d6a87