### PR TITLE
Fix phi3 feedback serialization for Pydantic v2

### DIFF
--- a/osiris/server.py
+++ b/osiris/server.py
@@ -309,7 +309,11 @@ async def submit_phi3_feedback(feedback: FeedbackItem):
             f.write(json.dumps(feedback_dict) + "\n")
 
         # Add to LanceDB and publish event
-        db.append_feedback(feedback_dict)
+        # Explicit serialization for Pydantic v2 with fallback for v1
+        if hasattr(feedback, "model_dump"):
+            db.append_feedback(feedback.model_dump())
+        else:
+            db.append_feedback(feedback.dict())
         if getattr(event_bus, "pubsub", None):
             await event_bus.publish("phi3.feedback.submitted", json.dumps(feedback_dict))
         


### PR DESCRIPTION
## Summary
- ensure submit_phi3_feedback serializes FeedbackItem with `model_dump()` before calling `append_feedback`
- fallback to `.dict()` for Pydantic v1 compatibility

## Testing
- `pytest -q tests/test_feedback_versioning.py::test_submit_phi3_feedback_stores_version -q`
- `pytest -q` *(fails: 8 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68451cb99d84832fa8b79702e7d9605d