### PR TITLE
Handle None responses in LLM client

### DIFF
--- a/osiris/llm_client.py
+++ b/osiris/llm_client.py
@@ -60,6 +60,10 @@ class LLMClient:
             f"/generate?model_id={model_id}",
             json={"prompt": prompt, "max_length": max_length},
         )
+        if resp is None:
+            logger.error("LLM request failed and returned no response")
+            return None
+
         return resp.json()
 
     def propose_trade_adjustments(


### PR DESCRIPTION
## Summary
- handle missing responses in `LLMClient.generate`

## Testing
- `pytest -q tests/test_llm_client.py` *(fails: AssertionError: HTTPError not raised)*

------
https://chatgpt.com/codex/tasks/task_e_68452620882c832f87a2c2f7b21874c3