### PR TITLE
Fix speak endpoint awaiting tts model

### DIFF
--- a/osiris/server.py
+++ b/osiris/server.py
@@ -387,7 +387,11 @@ async def score_proposal_with_hermes(request: ScoreRequest):
 
 @app.post("/speak", tags=["tts"])
 async def speak(request: SpeakRequest):
-    audio_bytes = tts_model.synth(request.text, exaggeration=request.exaggeration, ref_wav_b64=request.ref_wav_b64)
+    audio_bytes = await tts_model.synth(
+        request.text,
+        exaggeration=request.exaggeration,
+        ref_wav_b64=request.ref_wav_b64,
+    )
     return Response(content=audio_bytes, media_type="audio/wav")
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -87,7 +87,11 @@ def test_health_endpoint_db_query_exception():
 def test_speak_endpoint():
     """Test /speak endpoint for TTS"""
     mock_audio_data = b"RIFFxxxxWAVEfmt \x10\x00\x00\x00\x01\x00\x01\x00\x22\x56\x00\x00\x44\xac\x00\x00\x02\x00\x10\x00dataxxxx"
-    with patch("osiris.server.tts_model.synth", return_value=mock_audio_data) as mock_synth:
+    with patch(
+        "osiris.server.tts_model.synth",
+        new_callable=AsyncMock,
+        return_value=mock_audio_data,
+    ) as mock_synth:
         client = TestClient(app)
         response = client.post("/speak", json={"text": "hello world"})
         assert response.status_code == 200


### PR DESCRIPTION
## Summary
- await TTS synthesis in speak endpoint
- update test to patch async synth method

## Testing
- `pytest tests/test_server.py::test_speak_endpoint -q`

------
https://chatgpt.com/codex/tasks/task_e_684525fd2a28832f8ee20a966144c2a4