### PR TITLE
Fix phi3_adapter_date default

### DIFF
--- a/osiris/server.py
+++ b/osiris/server.py
@@ -175,7 +175,7 @@ logger = logging.getLogger(__name__)
 print("[Side-car] loading models …")
 load_hermes_model()
 load_phi3_model()
-phi3_adapter_date = loader.phi3_adapter_date
+phi3_adapter_date: Optional[str] = None
 tts_model = ChatterboxTTS(model_dir=CHATTERBOX_MODEL_DIR, device=DEVICE, event_bus=event_bus)
 print("[Side-car] models ready.")
 
@@ -407,7 +407,7 @@ async def health():
         "status": status,
         "hermes_loaded": hermes_ok,
         "phi3_loaded": phi3_ok,
-        "phi3_adapter_date": loader.phi3_adapter_date,
+        "phi3_adapter_date": phi3_adapter_date,
     }
 
     try:


### PR DESCRIPTION
## Summary
- ensure `phi3_adapter_date` defaults to `None`
- return patched `phi3_adapter_date` from health endpoint

## Testing
- `pytest -q tests/test_adapter_hot_swap.py::TestHealthEndpoint::test_health_endpoint_with_adapter_date -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_68452a567770832f92409a6fe80516aa