### PR TITLE
Fix JSON logging in trade proposal endpoint

### DIFF
--- a/osiris/server.py
+++ b/osiris/server.py
@@ -361,7 +361,10 @@ async def propose_trade_adjustments(request: PromptRequest):
     }
 
     with open(PHI3_FEEDBACK_LOG_FILE, "a") as f:
-        json.dump(log_entry, f)
+        # ``json.dump`` may emit multiple ``write`` calls when used with
+        # ``mock_open`` in tests, so explicitly dump to a string first
+        # to ensure a single write containing valid JSON.
+        f.write(json.dumps(log_entry))
         f.write("\n")
 
     if getattr(event_bus, "pubsub", None):


### PR DESCRIPTION
## Summary
- ensure propose_trade_adjustments writes valid JSON to the feedback log

## Testing
- `pytest -q tests/test_feedback_mechanism.py::TestFeedbackMechanism::test_log_propose_trade_adjustments -q`

------
https://chatgpt.com/codex/tasks/task_e_68452d5136bc832fbbc390df1a1ef9fd