### PR TITLE
Fix open mocking path

### DIFF
--- a/tests/test_feedback_mechanism.py
+++ b/tests/test_feedback_mechanism.py
@@ -160,8 +160,9 @@ class TestFeedbackMechanism(unittest.TestCase):
         )
 
     # Test Case 3: load_recent_feedback Function (Direct Test)
+    @patch("osiris.server.open", new_callable=mock_open)  # Mock the open used in server
     @patch("builtins.print")  # Mock print to check error logs
-    def test_load_recent_feedback_logic(self, mock_print):
+    def test_load_recent_feedback_logic(self, mock_print, mock_file_open):
         # Scenario A: Valid Feedback (3 relevant items, ask for 2)
         mock_data_valid = [
             {


### PR DESCRIPTION
## Summary
- mock `open` from `osiris.server` when testing feedback logic

## Testing
- `pytest tests/test_feedback_mechanism.py::TestFeedbackMechanism::test_load_recent_feedback_logic -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684530bc2c88832f968842281a2b4c89