### PR TITLE
Fix install target indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ run-dev-sidecar:
 
 # Serve documentation locally
 docs-serve:
-mkdocs serve -f mkdocs.yml
+	mkdocs serve -f mkdocs.yml
 
 install:
 	pip install -r requirements-torch.txt


### PR DESCRIPTION
## Summary
- fix docs-serve recipe indentation so makefile is valid

## Testing
- `make -n install`

------
https://chatgpt.com/codex/tasks/task_e_68453644a978832fad1a57bf3f36da31