### PR TITLE
Fix auto-gptq version pin

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 accelerate==0.27.2
-auto-gptq==0.7.1
+auto-gptq
 bitsandbytes
 fastapi==0.109.2
 huggingface-hub==0.20.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1886,9 +1886,7 @@ pyinstrument==5.0.2 \
 pyjwt[crypto]==2.10.1 \
     --hash=sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953 \
     --hash=sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb
-    # via
-    #   pygithub
-    #   pyjwt
+    # via pygithub
 pylint==2.17.7 \
     --hash=sha256:27a8d4c7ddc8c2f8c18aa0050148f89ffc09838142193fdbe98f172781a3ff87 \
     --hash=sha256:f4fcac7ae74cfe36bc8451e931d8438e4a476c20314b1101c458ad0f05191fad
@@ -2634,9 +2632,7 @@ urllib3==2.4.0 \
 uvicorn[standard]==0.27.1 \
     --hash=sha256:3d9a267296243532db80c83a959a3400502165ade2c1338dea4e67915fd4745a \
     --hash=sha256:5c89da2f3895767472a35556e539fd59f7edbe9b1e9c0e1c99eebeadc61838e4
-    # via
-    #   -r requirements.in
-    #   uvicorn
+    # via -r requirements.in
 uvloop==0.21.0 \
     --hash=sha256:0878c2640cf341b269b7e128b1a5fed890adc4455513ca710d77d5e93aa6d6a0 \
     --hash=sha256:10d66943def5fcb6e7b37310eb6b5639fd2ccbc38df1177262b0640c3ca68c1f \


### PR DESCRIPTION
## Summary
- loosen auto-gptq pin in requirements.in
- regenerate requirements.txt

## Testing
- `pip-compile --constraint=constraints_cpu.txt --generate-hashes --output-file=requirements.txt requirements.in`
- `make install` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_68453843dac4832f8e900703eac1d9f8