### PR TITLE
Fix Makefile tabs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,8 @@ docs-serve:
 	mkdocs serve -f mkdocs.yml
 
 install:
-       pip install -r requirements.txt
-       pip install -r requirements-dev.txt
+	pip install -r requirements.txt
+	pip install -r requirements-dev.txt
 
 # Check for up-to-date lock files
 lock:


### PR DESCRIPTION
## Summary
- correct spacing under the `install` target so it uses tab characters

## Testing
- `make -n install`

------
https://chatgpt.com/codex/tasks/task_e_6845477eb65c832f9d489441e92f2fff