### PR TITLE
Fix async test decorator

### DIFF
--- a/tests/test_feedback_mechanism.py
+++ b/tests/test_feedback_mechanism.py
@@ -4,6 +4,7 @@ import uuid
 import os
 import asyncio
 from unittest.mock import patch, mock_open, MagicMock, call, ANY
+import pytest
 import sys
 
 sys.modules.setdefault("sentry_sdk", MagicMock())
@@ -266,6 +267,7 @@ class TestFeedbackMechanism:
     # To directly test _generate_phi3_json, we need to mock its internal dependencies like outlines
     @patch("outlines.generate.json")
     @patch("osiris.server.load_recent_feedback")
+    @pytest.mark.asyncio
     async def test_prompt_augmentation_logic(
         self, mock_load_feedback, mock_outlines_gen_json_factory
     ):


### PR DESCRIPTION
## Summary
- use `pytest.mark.asyncio` for async test
- import pytest for decorator usage

## Testing
- `pytest tests/test_feedback_mechanism.py::TestFeedbackMechanism::test_prompt_augmentation_logic -vv` *(fails: ModuleNotFoundError: No module named 'outlines')*

------
https://chatgpt.com/codex/tasks/task_e_6845478ad3d8832f9e381e1015e504cd