### PR TITLE
Fix Makefile install rule and async test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,8 @@ docs-serve:
 	mkdocs serve -f mkdocs.yml
 
 install:
-       pip install -r requirements.txt
-       pip install -r requirements-dev.txt
+	pip install -r requirements.txt
+	pip install -r requirements-dev.txt
 
 # Check for up-to-date lock files
 lock:

--- a/tests/test_feedback_mechanism.py
+++ b/tests/test_feedback_mechanism.py
@@ -5,6 +5,7 @@ import os
 import asyncio
 from unittest.mock import patch, mock_open, MagicMock, call, ANY
 import sys
+import pytest
 
 sys.modules.setdefault("sentry_sdk", MagicMock())
 
@@ -266,6 +267,7 @@ class TestFeedbackMechanism:
     # To directly test _generate_phi3_json, we need to mock its internal dependencies like outlines
     @patch("outlines.generate.json")
     @patch("osiris.server.load_recent_feedback")
+    @pytest.mark.asyncio
     async def test_prompt_augmentation_logic(
         self, mock_load_feedback, mock_outlines_gen_json_factory
     ):


### PR DESCRIPTION
## Summary
- fix indent on `install` target in Makefile
- mark async test with `pytest.mark.asyncio`

## Testing
- `make install` *(fails: Operation cancelled by user)*
- `pytest -k "prompt_augmentation_logic" -vv tests/test_feedback_mechanism.py` *(fails: Client.__init__ got unexpected keyword argument)*

------
https://chatgpt.com/codex/tasks/task_e_6845477752cc832f97579f0de1da60b9