### PR TITLE
Fix JSON writing for trade adjustment logs

### DIFF
--- a/osiris/server.py
+++ b/osiris/server.py
@@ -362,10 +362,7 @@ async def propose_trade_adjustments(request: PromptRequest):
     }
 
     with open(PHI3_FEEDBACK_LOG_FILE, "a") as f:
-        # ``json.dump`` may emit multiple ``write`` calls when used with
-        # ``mock_open`` in tests, so explicitly dump to a string first
-        # to ensure a single write containing valid JSON.
-        f.write(json.dumps(log_entry))
+        json.dump(log_entry, f)
         f.write("\n")
 
     if getattr(event_bus, "pubsub", None):


### PR DESCRIPTION
## Summary
- ensure PHI3 feedback log entries use `json.dump` for valid JSON

## Testing
- `pytest tests/test_feedback_mechanism.py::TestFeedbackMechanism::test_log_propose_trade_adjustments -vv` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68454eb3a470832fa49d6fb35f15b0ea