### PR TITLE
Update pyproject path settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "osiris"
 version = "0.0.0"
 
 [tool.setuptools.packages.find]
-include = ["osiris*", "llm_sidecar*", "osiris_policy*"]
+where = ["src"]
 
 [tool.black]
 line-length = 88
@@ -27,11 +27,11 @@ select = ["E9"]
 version_variable = "pyproject.toml:version"
 tag_format = "v{version}"
 
-[tool.pytest.ini_options]
 # Specifies that pytest should look for modules starting in the root directory.
 # This is critical for resolving ModuleNotFoundError issues during test collection.
+[tool.pytest.ini_options]
 pythonpath = [
-  "."
+  "src"
 ]
 # Configures the default scope for asyncio test fixtures.
 asyncio_default_fixture_loop_scope = "function"


### PR DESCRIPTION
## Summary
- update setuptools package discovery to use `src` layout
- configure pytest to include `src` on PYTHONPATH

## Testing
- `pre-commit run --files pyproject.toml`
- `pytest -q` *(fails: ModuleNotFoundError for several dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68454e8397cc832fb0c29720213be79e