### PR TITLE
Fix feedback migration and harvest scripts

### DIFF
--- a/osiris/scripts/migrate_feedback.py
+++ b/osiris/scripts/migrate_feedback.py
@@ -1,17 +1,21 @@
+import json
 import lancedb
 import os
-from pydantic import BaseModel
-from typing import Any, Optional, Dict, List
+import pyarrow as pa
+from typing import Any, Dict, List, Optional
 
 
-# Define the target schema for the table, including schema_version
-class FeedbackSchemaWithVersion(BaseModel):
-    transaction_id: str
-    timestamp: str  # Assuming ISO format string
-    feedback_type: str
-    feedback_content: Any  # Using Any for flexibility as in original task
-    corrected_proposal: Optional[Dict[str, Any]] = None
-    schema_version: str
+# Define the target pyarrow schema for the migrated table
+final_schema = pa.schema(
+    [
+        pa.field("transaction_id", pa.string()),
+        pa.field("timestamp", pa.string()),
+        pa.field("feedback_type", pa.string()),
+        pa.field("feedback_content", pa.string()),
+        pa.field("corrected_proposal", pa.string()),
+        pa.field("schema_version", pa.string()),
+    ]
+)
 
 
 def migrate_data():
@@ -55,79 +59,45 @@ def migrate_data():
     # 3. Iterate and update records
     processed_records: List[Dict[str, Any]] = []
     for record in records:
-        # Ensure record is a mutable dict
         record_dict = dict(record)
         if record_dict.get("schema_version") is None:
             record_dict["schema_version"] = "1.0"
+
+        cp = record_dict.get("corrected_proposal")
+        if isinstance(cp, dict):
+            record_dict["corrected_proposal"] = json.dumps(cp)
+
+        fc = record_dict.get("feedback_content")
+        if not isinstance(fc, str):
+            record_dict["feedback_content"] = json.dumps(fc)
+
         processed_records.append(record_dict)
 
     processed_count = len(processed_records)
     print(f"Processed {processed_count} records. Added 'schema_version' where missing.")
 
-    # 4. If the temporary table already exists, delete it.
-    try:
-        if temp_table_name in db.table_names():
-            db.drop_table(temp_table_name)
-            print(f"Deleted existing temporary table '{temp_table_name}'.")
-    except Exception as e:
-        print(f"Error deleting existing temporary table '{temp_table_name}'. {e}")
-        return
-
-    # 5. Create the new temporary table with the defined schema
-    try:
-        temp_table = db.create_table(temp_table_name, schema=FeedbackSchemaWithVersion)
-        print(f"Created new temporary table '{temp_table_name}' with target schema.")
-    except Exception as e:
-        print(f"Error creating temporary table '{temp_table_name}'. {e}")
-        # Attempt to clean up if records were processed but table creation failed
-        if processed_count > 0 and temp_table_name in db.table_names():
-            db.drop_table(temp_table_name)
-        return
-
-    # 6. Add all processed records to this temporary table
-    if processed_records:
-        try:
-            temp_table.add(processed_records)
-            print(f"Added {len(processed_records)} records to '{temp_table_name}'.")
-        except Exception as e:
-            print(f"Error adding records to temporary table '{temp_table_name}'. {e}")
-            # Clean up by dropping the temp table if add fails
-            db.drop_table(temp_table_name)
-            return
-    else:
-        print("No records to add to the temporary table.")
-
-    # 7. Delete the original table
+    # 4. Delete the original table if it exists
     try:
         if original_table_name in db.table_names():
             db.drop_table(original_table_name)
             print(f"Deleted original table '{original_table_name}'.")
-        else:
-            print(
-                f"Original table '{original_table_name}' not found for deletion, perhaps already deleted or renamed."
-            )
     except Exception as e:
         print(f"Error deleting original table '{original_table_name}'. {e}")
-        # At this point, we have data in temp_table. Critical decision here.
-        # For safety, maybe we should not proceed with rename if old table deletion fails.
-        # However, if the old table was already gone, that's okay.
-        # The check `original_table_name in db.table_names()` handles the "already gone" case.
-        # If it exists and deletion fails, that's a more serious issue.
         return
 
-    # 8. Rename the temporary table to the original table name
+    # 5. Create the migrated table with the defined schema
     try:
-        db.rename_table(temp_table_name, original_table_name)
+        db.create_table(
+            original_table_name,
+            data=processed_records,
+            schema=final_schema,
+            mode="overwrite",
+        )
         print(
-            f"Renamed temporary table '{temp_table_name}' to '{original_table_name}'."
+            f"Created migrated table '{original_table_name}' with new schema and {processed_count} records."
         )
     except Exception as e:
-        print(
-            f"Error renaming temporary table '{temp_table_name}' to '{original_table_name}'. {e}"
-        )
-        print(
-            f"CRITICAL: Data is now in '{temp_table_name}'. Manual intervention may be required."
-        )
+        print(f"Error creating migrated table '{original_table_name}'. {e}")
         return
 
     print(


### PR DESCRIPTION
## Summary
- correct schema handling in migrate_feedback.py using pyarrow
- drop original table and create new table using processed data
- fix harvest script filtering and output logic
- extend harvest to include transaction_id and use feedback_content

## Testing
- `pytest tests/test_feedback_versioning.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68454ed87a10832fb5649f297652bee3