### PR TITLE
Add pyarrow requirement to docs

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,6 @@ transformers
 accelerate
 auto-gptq
 lancedb
-pyarrow
+pyarrow  # required by LanceDB
 redis
 python-dotenv


### PR DESCRIPTION
## Summary
- document LanceDB's pyarrow dependency

## Testing
- `pre-commit run --files requirements.in requirements-dev.in`
- `pytest` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6845519fbfc8832fb5df0f48e6335849