### PR TITLE
Fix Makefile CUDA install option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 # Default to GPU environment. Override with 'make install ENV_TYPE=cpu'
+# You can also override PYTORCH_INDEX_URL directly if needed.
 ENV_TYPE ?= gpu
 
 # Define PyTorch index URL based on environment type
 ifeq ($(ENV_TYPE),gpu)
-    PYTORCH_INDEX_URL := https://download.pytorch.org/whl/cu121
+    PYTORCH_INDEX_URL ?= https://download.pytorch.org/whl/cu121
 else
-    PYTORCH_INDEX_URL := https://download.pytorch.org/whl/cpu
+    PYTORCH_INDEX_URL ?= https://download.pytorch.org/whl/cpu
 endif
 
 .PHONY: install compile-reqs test

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ git clone https://github.com/your/fork.git
 cd osiris
 cp .env.template .env
 make rebuild
+# Optionally install dependencies locally
+make install         # use ENV_TYPE=cpu if you don't have a GPU
 ```
 
 ---


### PR DESCRIPTION
## Summary
- allow overriding `PYTORCH_INDEX_URL` when installing locally
- document the new `ENV_TYPE` flag in the quick-start guide

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_684556783e98832facc44561aab2a00f