### PR TITLE
Fix harvest script version filtering

### DIFF
--- a/scripts/harvest_feedback.py
+++ b/scripts/harvest_feedback.py
@@ -68,8 +68,15 @@ def main():
     # If 'when' is stored as Arrow timestamp (nanoseconds):
     cutoff_timestamp_ns = int(cutoff_date.timestamp() * 1_000_000_000)
     # where_clause = f"feedback_type = 'correction' AND corrected_proposal IS NOT NULL AND corrected_proposal != '' AND \"when\" >= {cutoff_timestamp_ns}"
-    # Updated where_clause to include schema_version
-    where_clause = f"feedback_type = 'correction' AND corrected_proposal IS NOT NULL AND corrected_proposal != '' AND \"when\" >= {cutoff_timestamp_ns} AND schema_version = '{args.schema_version}'"
+    # Updated where_clause to include schema_version. The comparison uses LIKE
+    # so that prefix matches work (e.g. filtering with "1.0" will also match
+    # "1.0.1").
+    where_clause = (
+        "feedback_type = 'correction' AND corrected_proposal IS NOT NULL "
+        "AND corrected_proposal != '' "
+        f"AND \"when\" >= {cutoff_timestamp_ns} "
+        f"AND schema_version LIKE '{args.schema_version}%'"
+    )
 
     query = table.search().where(where_clause)
 


### PR DESCRIPTION
## Summary
- update harvest_feedback to match schema_version prefix

## Testing
- `pytest tests/test_feedback_versioning.py -vv`
- `pytest tests/test_harvest.py::TestHarvestFeedback::test_default_extraction -vv` *(fails: 'LanceTable' object has no attribute 'count_rows')*

------
https://chatgpt.com/codex/tasks/task_e_684556af85b0832fa2c0c1c11fb37f83