### PR TITLE
Harden Dockerfile and update build docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Open‑source trading stack with local LLM agents.
 git clone https://github.com/your/fork.git
 cd osiris
 cp .env.template .env
+docker build --secret id=hf_token_secret,src=/path/to/token.txt -t osiris .
 make rebuild
 ```
 

--- a/docs/DEV_GUIDE.md
+++ b/docs/DEV_GUIDE.md
@@ -161,7 +161,11 @@ configured commission and slippage models when updating the portfolio.
 If the container fails due to VRAM limits, lower `MAX_TOKENS` in the `.env` or switch to CPU mode by setting `DEVICE=cpu`. The `vram_watchdog` service can automatically restart the sidecar when usage exceeds a threshold.
 
 ## Build and deploy
-To rebuild containers use:
+To build the Docker image manually and supply a Hugging Face token use BuildKit secrets:
+```bash
+docker build --secret id=hf_token_secret,src=/path/to/token.txt -t osiris .
+```
+To rebuild all containers via Compose:
 ```bash
 make rebuild
 ```

--- a/docs/SECURITY_SECRETS.md
+++ b/docs/SECURITY_SECRETS.md
@@ -10,8 +10,9 @@ recommended improvements.
   included a real looking `POLYGON_API_KEY`.
 * CI/CD workflows reference GitHub secrets for publishing images and docs.
 * Docker and Kubernetes manifests rely on environment variables for injecting
-  credentials. Examples include the `HF_TOKEN` build argument in the Dockerfile
-  and placeholders in `docker/docker-compose.cloud.yaml`.
+  credentials. The `HF_TOKEN` is now provided at build time using a BuildKit
+  secret (`hf_token_secret`) instead of a build argument. Compose files still
+  contain placeholders in `docker/docker-compose.cloud.yaml`.
 
 ## Issues Identified
 


### PR DESCRIPTION
## Summary
- enable Docker BuildKit syntax and mount HF token as a secret
- set `PYTHONPATH` without unused variable references
- document BuildKit secret usage in the dev guide and README
- clarify HF_TOKEN handling in the security guide

## Testing
- `PYTHONPATH=. pytest tests/hitl/test_hitl_pr.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684556b90c1c832f83b2a7f9072af14b