### PR TITLE
Fix harvest feedback test

### DIFF
--- a/osiris/__init__.py
+++ b/osiris/__init__.py
@@ -2,7 +2,10 @@
 
 __version__ = "0.2.1"
 
-from . import llm_sidecar
-from . import server
+# Avoid importing any heavy submodules at package import time so that tests that
+# merely import ``osiris`` don't pull in optional runtime dependencies.  The
+# ``llm_sidecar`` and ``server`` submodules can still be imported explicitly via
+# ``from osiris import llm_sidecar`` or ``from osiris import server`` thanks to
+# Python's package import mechanics.
 
 __all__ = ["llm_sidecar", "server"]

--- a/osiris/scripts/harvest_feedback.py
+++ b/osiris/scripts/harvest_feedback.py
@@ -74,7 +74,7 @@ def main():
         results = query.to_list()
     except Exception as query_error:
         print(f"Warning: LanceDB query failed ('{query_error}'). Falling back to manual Python filtering.")
-        all_records = table.to_list()
+        all_records = table.to_arrow().to_pylist()
         results = []
         for r in all_records:
             if (

--- a/tests/test_harvest.py
+++ b/tests/test_harvest.py
@@ -25,7 +25,7 @@ class TestHarvestFeedback(unittest.TestCase):
             assessment: str
             proposal: str
             corrected_proposal: str
-            when: str
+            when: int
             user_id: str
             schema_version: str
 
@@ -44,7 +44,7 @@ class TestHarvestFeedback(unittest.TestCase):
                 "assessment": "good",
                 "proposal": "p1",
                 "corrected_proposal": "",
-                "when": "2025-06-07T12:00:00Z",
+                "when": 1749297600000000000,
                 "user_id": "user1",
                 "schema_version": "1.0",
             },
@@ -54,7 +54,7 @@ class TestHarvestFeedback(unittest.TestCase):
                 "assessment": "",
                 "proposal": "p2",
                 "corrected_proposal": '{"action": "BUY"}',
-                "when": "2025-06-07T13:00:00Z",
+                "when": 1749301200000000000,
                 "user_id": "user1",
                 "schema_version": "1.0",
             },


### PR DESCRIPTION
## Summary
- avoid importing heavy modules when loading `osiris`
- adjust `harvest_feedback` fallback logic for new LanceDB API
- update test schema and sample data to use integer timestamps

## Testing
- `pytest tests/test_harvest.py::TestHarvestFeedback::test_default_extraction -vv -s`
- `pytest tests/test_harvest.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684557d51c88832fb015c7babf3968c8