### PR TITLE
Fix harvest feedback filtering and enable versioning test

### DIFF
--- a/scripts/harvest_feedback.py
+++ b/scripts/harvest_feedback.py
@@ -69,7 +69,12 @@ def main():
     cutoff_timestamp_ns = int(cutoff_date.timestamp() * 1_000_000_000)
     # where_clause = f"feedback_type = 'correction' AND corrected_proposal IS NOT NULL AND corrected_proposal != '' AND \"when\" >= {cutoff_timestamp_ns}"
     # Updated where_clause to include schema_version
-    where_clause = f"feedback_type = 'correction' AND corrected_proposal IS NOT NULL AND corrected_proposal != '' AND \"when\" >= {cutoff_timestamp_ns} AND schema_version = '{args.schema_version}'"
+    where_clause = (
+        "feedback_type = 'correction' "
+        "AND corrected_proposal IS NOT NULL AND corrected_proposal != '' "
+        f"AND \"when\" >= {cutoff_timestamp_ns} "
+        f"AND schema_version LIKE '{args.schema_version}%'"
+    )
 
     query = table.search().where(where_clause)
 

--- a/tests/test_feedback_versioning.py
+++ b/tests/test_feedback_versioning.py
@@ -8,12 +8,15 @@ correctly throughout its lifecycle, including:
 - Data migration for older records to a new schema.
 """
 import pytest
-pytest.skip("LanceDB not fully functional in test environment", allow_module_level=True)
 import lancedb
 import datetime
 import json
 import uuid
 import sys
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("sentry_sdk", MagicMock())
+import tests.test_imports  # Setup dependency stubs for redis and others
 from pydantic import BaseModel
 from typing import Optional, Dict, Any, List, Union
 


### PR DESCRIPTION
## Summary
- ensure `scripts/harvest_feedback.py` filters schema versions with `LIKE`
- unskip feedback versioning tests and stub missing dependencies

## Testing
- `pytest tests/test_feedback_versioning.py::test_harvest_feedback_py_filters_by_version -vv`

------
https://chatgpt.com/codex/tasks/task_e_684557cd0e70832fbd2304d79fa7abf8