### PR TITLE
Fix path resolution in nightly trainer test

### DIFF
--- a/tests/test_nightly_trainer.py
+++ b/tests/test_nightly_trainer.py
@@ -20,6 +20,7 @@ def test_driver_marketforge_task_set():
     candidate_paths = [
         repo_root / "nightly_trainer" / "driver.py",
         repo_root / "scripts" / "nightly_trainer" / "driver.py",
+        repo_root.parent / "nightly_trainer" / "driver.py",
     ]
 
     driver_script_path = next((p for p in candidate_paths if p.exists()), None)


### PR DESCRIPTION
## Summary
- allow `tests/test_nightly_trainer.py` to look one directory above repo root for `nightly_trainer/driver.py`
- keeps the driver stub in place which logs "trainer loop stub" when run with `--task-set marketforge`

## Testing
- `pytest tests/test_nightly_trainer.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68455b7e7cd4832faf6ecf511b4a76d9