### PR TITLE
Pin auto-gptq CUDA wheel

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ pydantic
 torch
 transformers
 accelerate
-auto-gptq
+auto-gptq==0.7.1+cu121
 lancedb
 pyarrow  # required by LanceDB
 redis

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ attrs==25.3.0
     #   aiohttp
     #   jsonschema
     #   referencing
-auto-gptq==0.7.1
+auto-gptq==0.7.1+cu121
     # via -r requirements.in
 certifi==2025.4.26
     # via requests


### PR DESCRIPTION
## Summary
- pin the CUDA build of auto-gptq
- regenerate requirements (manual update because pip-compile cannot access the package)

## Testing
- `pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cu121` *(fails: No matching distribution found for auto-gptq==0.7.1+cu121)*

------
https://chatgpt.com/codex/tasks/task_e_68455b649f30832f8c2a412ed1e881b5