### PR TITLE
feat(dgm): add patch telemetry counters (DGM-08)

### DIFF
--- a/src/dgm_kernel/metrics.py
+++ b/src/dgm_kernel/metrics.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+from prometheus_client import Counter, CollectorRegistry, REGISTRY as DEFAULT_REGISTRY
+
+_PATCH_APPLIED = "dgm_patches_applied_total"
+_PATCH_GENERATION = "dgm_patch_generation_total"
+
+_counters: Dict[CollectorRegistry, Dict[str, Counter]] = {}
+
+
+def _get_or_create(name: str, labels: List[str], help_text: str, registry: CollectorRegistry) -> Counter:
+    if registry not in _counters:
+        _counters[registry] = {}
+    metric = _counters[registry].get(name)
+    if metric is None:
+        metric = Counter(name, help_text, labels, registry=registry)
+        _counters[registry][name] = metric
+    if not isinstance(metric, Counter):
+        raise TypeError(f"Metric {name} in registry is not a Counter")
+    return metric
+
+
+def increment_patch_generation(*, mutation: str, result: str, registry: Optional[CollectorRegistry] = None) -> None:
+    reg = registry if registry is not None else DEFAULT_REGISTRY
+    c = _get_or_create(_PATCH_GENERATION, ["mutation", "result"], "Total number of patches generated", reg)
+    c.labels(mutation=mutation, result=result).inc()
+
+
+def increment_patch_apply(*, mutation: str, result: str, registry: Optional[CollectorRegistry] = None) -> None:
+    reg = registry if registry is not None else DEFAULT_REGISTRY
+    c = _get_or_create(_PATCH_APPLIED, ["mutation", "result"], "Total number of patches applied", reg)
+    c.labels(mutation=mutation, result=result).inc()

--- a/tests/dgm_kernel_tests/test_metrics.py
+++ b/tests/dgm_kernel_tests/test_metrics.py
@@ -1,0 +1,75 @@
+import importlib
+import asyncio
+from pathlib import Path
+from typing import Dict
+import importlib
+
+import pytest
+from prometheus_client import CollectorRegistry
+
+from dgm_kernel import meta_loop, metrics
+
+
+def get_metric_value(registry: CollectorRegistry, name: str, labels: Dict[str, str]) -> float:
+    value = registry.get_sample_value(name, labels=labels)
+    return value if value is not None else 0.0
+
+
+@pytest.mark.asyncio
+async def test_generate_patch_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = CollectorRegistry(auto_describe=True)
+    monkeypatch.setattr(meta_loop.metrics, "DEFAULT_REGISTRY", registry)
+    monkeypatch.setattr(metrics, "DEFAULT_REGISTRY", registry)
+
+    monkeypatch.setattr(meta_loop, "draft_patch", lambda traces: {"target": "t.py", "before": "", "after": "code"})
+    monkeypatch.setattr(meta_loop, "_generate_patch", lambda code: code)
+
+    before_val = get_metric_value(registry, "dgm_patch_generation_total", {"mutation": meta_loop._MUTATION_NAME, "result": "success"})
+    patch = await meta_loop.generate_patch([{}])
+    assert patch is not None
+    assert get_metric_value(registry, "dgm_patch_generation_total", {"mutation": meta_loop._MUTATION_NAME, "result": "success"}) == before_val + 1.0
+
+
+@pytest.mark.asyncio
+async def test_generate_patch_metrics_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = CollectorRegistry(auto_describe=True)
+    monkeypatch.setattr(meta_loop.metrics, "DEFAULT_REGISTRY", registry)
+    monkeypatch.setattr(metrics, "DEFAULT_REGISTRY", registry)
+
+    monkeypatch.setattr(meta_loop, "draft_patch", lambda traces: None)
+
+    before_val = get_metric_value(registry, "dgm_patch_generation_total", {"mutation": meta_loop._MUTATION_NAME, "result": "failure"})
+    patch = await meta_loop.generate_patch([{}])
+    assert patch is None
+    assert get_metric_value(registry, "dgm_patch_generation_total", {"mutation": meta_loop._MUTATION_NAME, "result": "failure"}) == before_val + 1.0
+
+
+def test_apply_patch_metrics_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = CollectorRegistry(auto_describe=True)
+    monkeypatch.setattr(meta_loop.metrics, "DEFAULT_REGISTRY", registry)
+    monkeypatch.setattr(metrics, "DEFAULT_REGISTRY", registry)
+
+    target = tmp_path / "mod.py"
+    patch = {"target": str(target), "after": "", "before": ""}
+
+    before_val = get_metric_value(registry, "dgm_patches_applied_total", {"mutation": meta_loop._MUTATION_NAME, "result": "success"})
+    assert meta_loop._apply_patch(patch) is True
+    assert get_metric_value(registry, "dgm_patches_applied_total", {"mutation": meta_loop._MUTATION_NAME, "result": "success"}) == before_val + 1.0
+
+
+def test_apply_patch_metrics_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = CollectorRegistry(auto_describe=True)
+    monkeypatch.setattr(meta_loop.metrics, "DEFAULT_REGISTRY", registry)
+    monkeypatch.setattr(metrics, "DEFAULT_REGISTRY", registry)
+
+    target = tmp_path / "mod.py"
+    patch = {"target": str(target), "after": "", "before": ""}
+
+    def fail_import(name: str):
+        raise ImportError("boom")
+
+    monkeypatch.setattr(importlib, "import_module", fail_import)
+
+    before_val = get_metric_value(registry, "dgm_patches_applied_total", {"mutation": meta_loop._MUTATION_NAME, "result": "failure"})
+    assert meta_loop._apply_patch(patch) is False
+    assert get_metric_value(registry, "dgm_patches_applied_total", {"mutation": meta_loop._MUTATION_NAME, "result": "failure"}) == before_val + 1.0


### PR DESCRIPTION
## Summary
- add a small metrics helper in `dgm_kernel`
- emit Prometheus counters during patch generation and application
- test metrics with isolated registries

## Testing
- `OSIRIS_TEST=1 python -m pip install -r requirements-dgm-tests.txt -q`
- `pytest -q tests/dgm_kernel_tests`
- `PYTHONPATH=src python -m mypy --strict -p dgm_kernel`
- `pytest --cov=src/dgm_kernel -q tests/dgm_kernel_tests`

------
https://chatgpt.com/codex/tasks/task_e_6865cdb56c4c832f9f64234c8a033819