### PR TITLE
feat(dgm): add meta-loop self-healing logic (DGM-07)

### DIFF
--- a/tests/dgm_kernel_tests/test_meta_loop.py
+++ b/tests/dgm_kernel_tests/test_meta_loop.py
@@ -447,7 +447,7 @@ def test_loop_forever_rolls_back_and_mutates(monkeypatch):
             raise StopIteration
 
     monkeypatch.setattr(meta_loop, "_verify_patch", fake_verify)
-    monkeypatch.setattr(meta_loop, "_generate_patch", fake_generate)
+    monkeypatch.setattr(meta_loop, "_generate_patch_async", fake_generate)
     monkeypatch.setattr(meta_loop, "_rollback", fake_rollback)
     monkeypatch.setattr(meta_loop, "fetch_recent_traces", fake_fetch)
     monkeypatch.setattr(time, "sleep", stop_sleep)
@@ -467,4 +467,4 @@ def test_loop_forever_rolls_back_and_mutates(monkeypatch):
             meta_loop.loop_forever()
 
     assert calls["rollback"] == 1
-    assert calls["generate"] == meta_loop.MAX_MUTATIONS_PER_LOOP
+    assert calls["generate"] == 1

--- a/tests/dgm_kernel_tests/test_meta_loop_self_heal.py
+++ b/tests/dgm_kernel_tests/test_meta_loop_self_heal.py
@@ -1,0 +1,118 @@
+import importlib
+import os
+import sys
+import time
+from collections import defaultdict
+from hypothesis import given, strategies as st, settings, HealthCheck
+import pytest
+
+class _RedisModule:
+    class Redis:
+        def __init__(self, *_, **__):
+            self._client = SimpleRedis()
+
+        def __getattr__(self, name):
+            return getattr(self._client, name)
+
+    class exceptions:
+        class RedisError(Exception):
+            ...
+
+
+sys.modules.setdefault("redis", _RedisModule())
+
+class SimpleRedis:
+    def __init__(self):
+        self.store = defaultdict(list)
+
+    def lpush(self, name, value):
+        self.store[name].insert(0, value)
+
+    def rpop(self, name):
+        lst = self.store[name]
+        if lst:
+            return lst.pop()
+        return None
+
+    def ping(self):
+        return True
+
+
+from dgm_kernel import meta_loop
+
+@pytest.fixture
+def fake_redis():
+    r = SimpleRedis()
+    r.ping()
+    return r
+
+
+@pytest.fixture(autouse=True)
+def patch_redis_client(monkeypatch, fake_redis):
+    monkeypatch.setattr(meta_loop, "REDIS", fake_redis)
+
+
+@settings(max_examples=1, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(st.just(5))
+def test_sleep_after_rollbacks(monkeypatch, num_failures):
+    async def fake_fetch(*_args, **_kwargs):
+        return [{}]
+
+    async def gen_patch(traces):
+        return {"target": "t.py", "before": "", "after": ""}
+
+    async def verify(traces, patch):
+        return False
+
+    rollbacks = {"n": 0}
+
+    def rb(_patch):
+        rollbacks["n"] += 1
+
+    sleep_calls = []
+
+    def fake_sleep(s):
+        sleep_calls.append(s)
+        if rollbacks["n"] >= num_failures:
+            raise StopIteration
+
+    monkeypatch.setattr(meta_loop, "fetch_recent_traces", fake_fetch)
+    monkeypatch.setattr(meta_loop, "_generate_patch_async", gen_patch)
+    monkeypatch.setattr(meta_loop, "_verify_patch", verify)
+    monkeypatch.setattr(meta_loop, "_rollback", rb)
+    monkeypatch.setattr(time, "sleep", fake_sleep)
+
+    with pytest.raises(StopIteration):
+        meta_loop.loop_forever()
+
+    assert any(sec >= meta_loop.ROLLBACK_SLEEP_S for sec in sleep_calls)
+
+
+def test_env_var_reload(monkeypatch):
+    monkeypatch.setenv("DGM_MUTATION", "ASTRenameIdentifier")
+    importlib.reload(meta_loop)
+    assert type(meta_loop._mutation_strategy).__name__ == "ASTRenameIdentifier"
+
+    async def fetch(*_args, **_kwargs):
+        return [{}]
+
+    async def none_patch(traces):
+        return None
+
+    calls = {"sleep": 0}
+
+    def fake_sleep(_):
+        calls["sleep"] += 1
+        if calls["sleep"] > 3:
+            raise StopIteration
+
+    monkeypatch.setattr(meta_loop, "fetch_recent_traces", fetch)
+    monkeypatch.setattr(meta_loop, "_generate_patch_async", none_patch)
+    monkeypatch.setattr(time, "sleep", fake_sleep)
+
+    with pytest.raises(StopIteration):
+        meta_loop.loop_forever()
+
+    assert os.environ["DGM_MUTATION"] == "ASTInsertComment"
+    importlib.reload(meta_loop)
+    assert type(meta_loop._mutation_strategy).__name__ == "ASTInsertComment"


### PR DESCRIPTION
## Summary
- implement fallback mutation and rollback backoff in meta loop
- expose ROLLBACK_SLEEP_S constant
- alias async mutation generator as `_generate_patch_async`
- update loop_forever to use new strategy
- add unit tests for backoff and env var reload
- adjust existing meta loop test for new behaviour

## Testing
- `OSIRIS_TEST=1 python -m pip install -r requirements-dgm-tests.txt -q`
- `pytest -q tests/dgm_kernel_tests`
- `PYTHONPATH=src python -m mypy --strict -p dgm_kernel`


------
https://chatgpt.com/codex/tasks/task_e_6865cda28264832fb8801d6780680684