### PR TITLE
feat(dgm): Prom ServiceMonitor & initial Grafana panel (DGM-10)

### DIFF
--- a/deploy/dgm-kernel-chart/templates/grafana-dashboard.yaml
+++ b/deploy/dgm-kernel-chart/templates/grafana-dashboard.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.monitoring.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "dgm-kernel.fullname" . }}-grafana-dashboard
+  labels:
+    {{- include "dgm-kernel.labels" . | nindent 4 }}
+    app.kubernetes.io/component: grafana
+  annotations:
+    grafana_dashboard: "1"
+data:
+  dgm.json: |-
+    {
+      "title": "DGM Kernel Metrics",
+      "uid": "dgm-kernel",
+      "schemaVersion": 37,
+      "version": 1,
+      "panels": [
+        {
+          "type": "timeseries",
+          "title": "Patch Apply Rate",
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "targets": [{"expr": "rate(dgm_patch_apply_total[5m])", "refId": "A"}],
+          "gridPos": {"h": 6, "w": 12, "x": 0, "y": 0}
+        }
+      ]
+    }
+{{- end }}

--- a/deploy/dgm-kernel-chart/templates/servicemonitor.yaml
+++ b/deploy/dgm-kernel-chart/templates/servicemonitor.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.monitoring.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "dgm-kernel.fullname" . }}
+  labels:
+    {{- include "dgm-kernel.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "dgm-kernel.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - targetPort: 8000
+      path: /metrics
+      interval: {{ .Values.monitoring.interval }}
+{{- end }}

--- a/deploy/dgm-kernel-chart/values.yaml
+++ b/deploy/dgm-kernel-chart/values.yaml
@@ -9,3 +9,7 @@ service:
   type: ClusterIP
   port: 8000
   targetPort: 8000
+
+monitoring:
+  enabled: false
+  interval: 30s

--- a/docs/dgm/OBSERVABILITY.md
+++ b/docs/dgm/OBSERVABILITY.md
@@ -1,0 +1,11 @@
+# DGM Kernel Observability
+
+To enable Prometheus scraping and install the Grafana dashboard, deploy the chart with monitoring enabled:
+
+```bash
+helm install dgm-kernel ./deploy/dgm-kernel-chart --set monitoring.enabled=true
+```
+
+After installation, a dashboard titled **DGM Kernel Metrics** will appear in Grafana with a panel showing the 5‑minute rate of `dgm_patch_apply_total`.
+
+> _Screenshot of the dashboard goes here_


### PR DESCRIPTION
## Summary
- add `monitoring` values for DGM kernel chart
- expose ServiceMonitor when monitoring enabled
- stub Grafana dashboard for DGM metrics
- document how to enable monitoring

## Testing
- `helm lint deploy/dgm-kernel-chart` *(fails: helm not installed)*
- `helm template dgm-kernel ./deploy/dgm-kernel-chart | grep ServiceMonitor` *(fails: helm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6865d8663cb4832fa523c81fad684228