### PR TITLE
feat(dgm): unsafe-token Prometheus metric (DGM-08)

### DIFF
--- a/requirements-dgm-tests.txt
+++ b/requirements-dgm-tests.txt
@@ -5,3 +5,4 @@ hypothesis
 pydantic>=2,<3
 redis==6.2.0
 fakeredis>=2.19
+prometheus-client

--- a/src/dgm_kernel/metrics.py
+++ b/src/dgm_kernel/metrics.py
@@ -5,6 +5,10 @@ from prometheus_client import Counter, CollectorRegistry, REGISTRY as DEFAULT_RE
 
 _PATCH_APPLIED = "dgm_patches_applied_total"
 _PATCH_GENERATION = "dgm_patch_generation_total"
+unsafe_token_found_total = Counter(
+    "dgm_unsafe_token_found_total",
+    "Number of patches rejected due to dangerous tokens",
+)
 
 _counters: Dict[CollectorRegistry, Dict[str, Counter]] = {}
 


### PR DESCRIPTION
## Summary
- track rejected patches with new `unsafe_token_found_total` Prometheus counter
- hook metric into `_verify_patch`
- improve `_apply_patch` reliability and patch generation loop
- refine trace fetching to log decoding failures
- add unit test for the unsafe token metric
- ensure Prometheus client is available for tests

## Testing
- `python -m pytest -q tests/dgm_kernel_tests`
- `MYPYPATH=src python -m mypy --strict -p dgm_kernel`


------
https://chatgpt.com/codex/tasks/task_e_6865dd44cf38832f8a6278a969ab000c