### PR TITLE
feat(dgm): ServiceMonitor & Prom alerts (DGM-10)

### DIFF
--- a/deploy/dgm-kernel-chart/templates/alerts.yaml
+++ b/deploy/dgm-kernel-chart/templates/alerts.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.alerts.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "dgm-kernel.fullname" . }}-alerts
+  labels:
+    {{- include "dgm-kernel.labels" . | nindent 4 }}
+spec:
+  groups:
+    - name: dgm.rules
+      rules:
+        - alert: HighPatchFailureRate
+          expr: |
+            rate(dgm_patches_applied_total{result="failure"}[5m])
+              /
+            rate(dgm_patches_applied_total[5m]) * 100 > 50
+          for: 5m
+          labels:
+            severity: warning
+        - alert: UnsafeTokenSpike
+          expr: rate(dgm_unsafe_token_found_total[5m]) > 0
+          for: 1m
+          labels:
+            severity: warning
+{{- end }}

--- a/deploy/dgm-kernel-chart/templates/servicemonitor.yaml
+++ b/deploy/dgm-kernel-chart/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.monitoring.enabled }}
+{{- if .Values.servicemonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -12,5 +12,5 @@ spec:
   endpoints:
     - targetPort: 8000
       path: /metrics
-      interval: {{ .Values.monitoring.interval }}
+      interval: 15s
 {{- end }}

--- a/deploy/dgm-kernel-chart/values.yaml
+++ b/deploy/dgm-kernel-chart/values.yaml
@@ -13,3 +13,9 @@ service:
 monitoring:
   enabled: false
   interval: 30s
+
+servicemonitor:
+  enabled: false
+
+alerts:
+  enabled: false

--- a/tests/deploy/test_render_chart.py
+++ b/tests/deploy/test_render_chart.py
@@ -1,0 +1,43 @@
+import shutil
+import subprocess
+from pathlib import Path
+import yaml
+import pytest
+
+CHART_DIR = Path(__file__).resolve().parents[2] / "deploy" / "dgm-kernel-chart"
+
+
+def render_chart(tmp_path, values):
+    values_file = tmp_path / "values.yaml"
+    values_file.write_text(yaml.safe_dump(values))
+    cmd = [
+        "helm",
+        "template",
+        "test",
+        str(CHART_DIR),
+        "--values",
+        str(values_file),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return list(yaml.safe_load_all(result.stdout))
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm not installed")
+def test_servicemonitor_and_alerts_render(tmp_path):
+    docs = render_chart(
+        tmp_path,
+        {"servicemonitor": {"enabled": True}, "alerts": {"enabled": True}},
+    )
+    kinds = [d.get("kind") for d in docs if isinstance(d, dict)]
+    assert "ServiceMonitor" in kinds
+    assert "PrometheusRule" in kinds
+
+    sm = next(d for d in docs if d.get("kind") == "ServiceMonitor")
+    ep = sm["spec"]["endpoints"][0]
+    assert ep["path"] == "/metrics"
+    assert ep["interval"] == "15s"
+
+    pr = next(d for d in docs if d.get("kind") == "PrometheusRule")
+    rule_names = [r["alert"] for g in pr["spec"]["groups"] for r in g["rules"]]
+    assert "HighPatchFailureRate" in rule_names
+    assert "UnsafeTokenSpike" in rule_names


### PR DESCRIPTION
## Summary
- add ServiceMonitor template with fixed 15s scrape interval
- add PrometheusRule for HighPatchFailureRate and UnsafeTokenSpike
- expose `servicemonitor.enabled` and `alerts.enabled` values
- test Helm template rendering when helm is available

## Testing
- `pip install --no-cache-dir -r requirements-tests.txt`
- `pip install pyyaml`
- `pytest tests/deploy/test_render_chart.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6865e261e0ec832f93079effbecc5eb6