### PR TITLE
feat(dgm): adaptive rollback back-off logic (DGM-11)

### DIFF
--- a/src/dgm_kernel/meta_loop.py
+++ b/src/dgm_kernel/meta_loop.py
@@ -335,6 +335,9 @@ def loop_forever() -> None:
                 os.environ["DGM_MUTATION"] = "ASTInsertComment"
 
         if rollback_streak >= 4:
+            metrics.rollback_backoff_total.inc()
+            os.environ["DGM_MUTATION"] = "ASTInsertComment"
+            rollback_streak = 0
             time.sleep(ROLLBACK_SLEEP_S)
         else:
             time.sleep(LOOP_WAIT_S)

--- a/src/dgm_kernel/metrics.py
+++ b/src/dgm_kernel/metrics.py
@@ -10,6 +10,12 @@ unsafe_token_found_total = Counter(
     "Number of patches rejected due to dangerous tokens",
 )
 
+# Counts how often the meta-loop backed off due to repeated rollbacks
+rollback_backoff_total = Counter(
+    "dgm_rollback_backoff_total",
+    "Number of times meta-loop slept due to consecutive rollbacks",
+)
+
 _counters: Dict[CollectorRegistry, Dict[str, Counter]] = {}
 
 


### PR DESCRIPTION
## Summary
- add rollback backoff counter metric
- trigger metric, sleep, and mutation reset on 4 consecutive rollbacks
- test counter increment and mutation reset

## Testing
- `pytest -q tests/dgm_kernel_tests`
- `MYPYPATH=src mypy -p dgm_kernel`

------
https://chatgpt.com/codex/tasks/task_e_6865e2693864832f8f1719e5cce3519b