### PR TITLE
feat(dgm): adaptive mutation scheduler (DGM-14)

### DIFF
--- a/src/dgm_kernel/meta_loop.py
+++ b/src/dgm_kernel/meta_loop.py
@@ -6,6 +6,7 @@ Darwin Gödel Machine — self-improving meta-loop (async capable)
 from __future__ import annotations
 
 import argparse
+from collections import deque
 import asyncio
 import difflib
 import importlib
@@ -25,6 +26,7 @@ import redis
 from dgm_kernel import metrics
 from dgm_kernel.llm_client import draft_patch
 from dgm_kernel.mutation_strategies import MutationStrategy
+from dgm_kernel.mutation_scheduler import MutationScheduler
 from dgm_kernel.prover import _get_pylint_score as _prover_pylint_score
 from dgm_kernel.prover import prove_patch
 from dgm_kernel.sandbox import run_patch_in_sandbox
@@ -56,15 +58,37 @@ if PATCH_HISTORY_FILE.exists():  # pragma: no cover – startup rewind
         log.error("Failed to read patch history: %s", exc)
 
 _MUTATION_NAME = os.getenv("DGM_MUTATION", "ASTInsertComment")
+_scheduler = MutationScheduler()
+_recent_rewards: deque[float] = deque(maxlen=5)
 
 # ───────────────────────────── mutation helpers ──────────────────────────────
 def _load_mutation() -> MutationStrategy:
     mod = importlib.import_module("dgm_kernel.mutation_strategies")
+    if not hasattr(mod, _MUTATION_NAME) and _MUTATION_NAME == "ASTInsertCommentAndRename":
+        from dgm_kernel.mutation_strategies import ASTInsertComment, ASTRenameIdentifier
+
+        class ASTInsertCommentAndRename:
+            def mutate(self, code: str) -> str:
+                code = ASTInsertComment().mutate(code)
+                return ASTRenameIdentifier().mutate(code)
+
+        setattr(mod, "ASTInsertCommentAndRename", ASTInsertCommentAndRename)
+
     cls = cast(type[MutationStrategy], getattr(mod, _MUTATION_NAME))
     return cls()
 
 
 _mutation_strategy = _load_mutation()
+
+
+def _set_mutation_strategy(name: str) -> None:
+    """Update global mutation strategy and mirror env var."""
+    global _MUTATION_NAME, _mutation_strategy
+    _MUTATION_NAME = name
+    os.environ["DGM_MUTATION"] = name
+    _mutation_strategy = _load_mutation()
+    if name == "ASTInsertComment":
+        _scheduler.__init__()
 
 
 def _mutate_code(code: str) -> str:
@@ -316,12 +340,23 @@ def loop_forever() -> None:
     while True:
         traces = asyncio.run(fetch_recent_traces())
 
+        avg_reward = (
+            sum(_recent_rewards) / len(_recent_rewards)
+            if _recent_rewards
+            else 0.0
+        )
+        chosen = _scheduler.next_strategy(avg_reward)
+        if chosen != _MUTATION_NAME:
+            _set_mutation_strategy(chosen)
+
         if pending:
             if not asyncio.run(_verify_patch(traces, pending)):
                 _rollback(pending)
                 pending = None
+                _recent_rewards.append(-1.0)
                 rollback_streak += 1
             else:
+                _recent_rewards.append(1.0)
                 rollback_streak = 0
         else:
             for _ in range(MAX_MUTATIONS_PER_LOOP):
@@ -332,11 +367,11 @@ def loop_forever() -> None:
                 none_streak += 1
 
             if none_streak >= 3:
-                os.environ["DGM_MUTATION"] = "ASTInsertComment"
+                _set_mutation_strategy("ASTInsertComment")
 
         if rollback_streak >= 4:
             metrics.rollback_backoff_total.inc()
-            os.environ["DGM_MUTATION"] = "ASTInsertComment"
+            _set_mutation_strategy("ASTInsertComment")
             rollback_streak = 0
             time.sleep(ROLLBACK_SLEEP_S)
         else:

--- a/src/dgm_kernel/mutation_scheduler.py
+++ b/src/dgm_kernel/mutation_scheduler.py
@@ -1,0 +1,30 @@
+"""Adaptive mutation strategy scheduler for DGM."""
+
+from __future__ import annotations
+
+class MutationScheduler:
+    """Simple scheduler that escalates mutation strategies when rewards drop."""
+
+    def __init__(self) -> None:
+        self._current = "ASTInsertComment"
+        self._bad_streak = 0
+        self._phase = 0
+
+    def next_strategy(self, prev_reward: float | None) -> str:
+        """Return the next mutation strategy based on previous reward."""
+        if prev_reward is None or prev_reward > 0:
+            self._bad_streak = 0
+        else:
+            self._bad_streak += 1
+
+        if self._phase == 0 and self._bad_streak >= 3:
+            self._current = "ASTRenameIdentifier"
+            self._phase = 1
+            self._bad_streak = 0
+        elif self._phase == 1 and self._bad_streak >= 3:
+            self._current = "ASTInsertCommentAndRename"
+            self._phase = 2
+            self._bad_streak = 0
+
+        return self._current
+

--- a/tests/dgm_kernel_tests/test_mutation_scheduler.py
+++ b/tests/dgm_kernel_tests/test_mutation_scheduler.py
@@ -1,0 +1,25 @@
+from dgm_kernel.mutation_scheduler import MutationScheduler
+
+
+def test_scheduler_progression() -> None:
+    sched = MutationScheduler()
+    rewards = [-1.0, -1.0, -1.0, -1.0, -1.0, -1.0]
+    strategies = [sched.next_strategy(r) for r in rewards]
+    assert strategies[0] == "ASTInsertComment"
+    assert strategies[1] == "ASTInsertComment"
+    assert strategies[2] == "ASTRenameIdentifier"
+    assert strategies[3] == "ASTRenameIdentifier"
+    assert strategies[4] == "ASTRenameIdentifier"
+    assert strategies[5] == "ASTInsertCommentAndRename"
+
+
+def test_positive_resets_streak() -> None:
+    sched = MutationScheduler()
+    assert sched.next_strategy(-1.0) == "ASTInsertComment"
+    assert sched.next_strategy(-1.0) == "ASTInsertComment"
+    assert sched.next_strategy(1.0) == "ASTInsertComment"
+    # after reset, need 3 more negatives to switch
+    sched.next_strategy(-1.0)
+    sched.next_strategy(-1.0)
+    assert sched.next_strategy(-1.0) == "ASTRenameIdentifier"
+


### PR DESCRIPTION
## Summary
- add MutationScheduler to adapt mutation strategy based on reward
- integrate scheduler into meta loop
- unit tests for scheduler progression and reset behaviour

## Testing
- `pytest -q tests/dgm_kernel_tests`
- `PYTHONPATH=src mypy -p dgm_kernel`

------
https://chatgpt.com/codex/tasks/task_e_6865e4d92d68832fa45f613b57b59cfa