### PR TITLE
feat(dgm): Helm HPA support (DGM-16)

### DIFF
--- a/deploy/dgm-kernel-chart/templates/hpa.yaml
+++ b/deploy/dgm-kernel-chart/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "dgm-kernel.fullname" . }}
+  labels:
+    {{- include "dgm-kernel.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "dgm-kernel.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+{{- end }}

--- a/deploy/dgm-kernel-chart/values.yaml
+++ b/deploy/dgm-kernel-chart/values.yaml
@@ -21,3 +21,8 @@ servicemonitor:
 
 alerts:
   enabled: false
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5

--- a/tests/deploy/test_render_hpa.py
+++ b/tests/deploy/test_render_hpa.py
@@ -1,0 +1,35 @@
+import shutil
+import subprocess
+from pathlib import Path
+import yaml
+import pytest
+
+CHART_DIR = Path(__file__).resolve().parents[2] / "deploy" / "dgm-kernel-chart"
+
+
+def render_chart(tmp_path, values):
+    values_file = tmp_path / "values.yaml"
+    values_file.write_text(yaml.safe_dump(values))
+    cmd = [
+        "helm",
+        "template",
+        "test",
+        str(CHART_DIR),
+        "--values",
+        str(values_file),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return list(yaml.safe_load_all(result.stdout))
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm not installed")
+def test_hpa_render(tmp_path):
+    docs = render_chart(
+        tmp_path,
+        {"autoscaling": {"enabled": True, "minReplicas": 2, "maxReplicas": 4}},
+    )
+    kinds = [d.get("kind") for d in docs if isinstance(d, dict)]
+    assert "HorizontalPodAutoscaler" in kinds
+    hpa = next(d for d in docs if d.get("kind") == "HorizontalPodAutoscaler")
+    assert hpa["spec"]["minReplicas"] == 2
+    assert hpa["spec"]["maxReplicas"] == 4


### PR DESCRIPTION
## Summary
- implement HorizontalPodAutoscaler template for dgm-kernel Helm chart
- add autoscaling options to chart values
- test rendering of the HPA when autoscaling is enabled

## Testing
- `helm template test deploy/dgm-kernel-chart --set autoscaling.enabled=true | grep HorizontalPodAutoscaler` *(fails: command not found)*
- `pytest tests/deploy/test_render_hpa.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6865e858f960832f9041f41c13f4c701