### PR TITLE
Add sandbox leak regression test

### DIFF
--- a/requirements-dgm-tests.txt
+++ b/requirements-dgm-tests.txt
@@ -7,3 +7,4 @@ redis==6.2.0
 fakeredis>=2.19
 prometheus-client
 requests>=2
+psutil

--- a/tests/dgm_kernel_tests/test_sandbox_leak.py
+++ b/tests/dgm_kernel_tests/test_sandbox_leak.py
@@ -1,0 +1,18 @@
+import sys
+import psutil
+import pytest
+
+
+def test_sandbox_leak():
+    if sys.platform.startswith("win"):
+        pytest.xfail("resource module missing")
+    from dgm_kernel.sandbox import Sandbox
+
+    proc = psutil.Process()
+    rss_before = proc.memory_info().rss
+    patch = {"after": "print('ok')"}
+    for _ in range(50):
+        Sandbox().run(patch)
+    rss_after = proc.memory_info().rss
+    assert rss_after - rss_before < 5 * 1024 * 1024
+


### PR DESCRIPTION
## Summary
- ensure Sandbox doesn't leak memory with repeated runs
- track RSS before/after using psutil
- require psutil for dgm tests

## Testing
- `pytest -q tests/dgm_kernel_tests/test_sandbox_leak.py`

------
https://chatgpt.com/codex/tasks/task_e_686814dd2a24832fa1706a19d9c9dd70