### PR TITLE
feat(dgm): pydantic trace validation

### DIFF
--- a/src/dgm_kernel/meta_loop.py
+++ b/src/dgm_kernel/meta_loop.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, cast
 import redis
 
 from dgm_kernel import metrics
+from dgm_kernel.trace_schema import Trace, validate_traces
 from dgm_kernel.crypto_sign import sign_patch, verify_patch
 from dgm_kernel.llm_client import draft_patch
 from dgm_kernel.mutation_strategies import MutationStrategy
@@ -132,12 +133,14 @@ async def fetch_recent_traces(n: int = 100) -> list[dict[str, Any]]:
                     exc,
                     idx,
                 )
+        decoded_count = len(traces)
+        traces = [t.model_dump() for t in validate_traces(traces)]
 
         if traces:
             log.info(
                 "Fetched %s traces successfully, encountered %s decoding errors.",
                 len(traces),
-                len(raw) - len(traces),
+                len(raw) - decoded_count,
             )
         elif raw:
             log.warning(

--- a/src/dgm_kernel/metrics.py
+++ b/src/dgm_kernel/metrics.py
@@ -22,6 +22,12 @@ patch_sig_invalid_total = Counter(
     "Number of patches rejected due to invalid signature",
 )
 
+# Counts validation failures for incoming traces
+trace_validation_fail_total = Counter(
+    "dgm_trace_validation_fail_total",
+    "Number of traces dropped due to schema validation errors",
+)
+
 _counters: Dict[CollectorRegistry, Dict[str, Counter]] = {}
 
 

--- a/src/dgm_kernel/trace_schema.py
+++ b/src/dgm_kernel/trace_schema.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import logging
+from typing import List
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from dgm_kernel import metrics
+
+log = logging.getLogger(__name__)
+
+
+class Trace(BaseModel):
+    """Execution trace record."""
+
+    id: str
+    timestamp: int
+    pnl: float
+    patch_id: str | None = None
+
+    model_config = ConfigDict(extra="ignore")
+
+
+def validate_traces(traces: List[dict]) -> List[Trace]:
+    """Validate raw trace dicts, dropping invalid rows."""
+    valid: List[Trace] = []
+    for idx, row in enumerate(traces):
+        try:
+            valid.append(Trace.model_validate(row))
+        except ValidationError as exc:  # pragma: no cover - error path tested
+            log.error(
+                "Trace validation failed for trace: %s. Error: %s. Trace index: %s",
+                row,
+                exc,
+                idx,
+            )
+            metrics.trace_validation_fail_total.inc()
+    return valid
+
+
+__all__ = ["Trace", "validate_traces"]

--- a/tests/dgm_kernel_tests/test_trace_schema.py
+++ b/tests/dgm_kernel_tests/test_trace_schema.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from prometheus_client import CollectorRegistry, Counter
+
+from dgm_kernel import metrics
+from dgm_kernel.trace_schema import validate_traces
+
+
+def setup_counter(monkeypatch):
+    registry = CollectorRegistry(auto_describe=True)
+    counter = Counter(
+        "dgm_trace_validation_fail_total",
+        "Number of traces dropped due to schema validation errors",
+        registry=registry,
+    )
+    monkeypatch.setattr(metrics, "trace_validation_fail_total", counter)
+    return counter
+
+
+def test_validate_traces_valid(monkeypatch):
+    counter = setup_counter(monkeypatch)
+    rows = [
+        {"id": "a", "timestamp": 1, "pnl": 0.5},
+        {"id": "b", "timestamp": 2, "pnl": -1.0, "patch_id": "p1"},
+    ]
+    traces = validate_traces(rows)
+    assert [t.id for t in traces] == ["a", "b"]
+    assert counter._value.get() == 0.0
+
+
+def test_validate_traces_invalid(monkeypatch):
+    counter = setup_counter(monkeypatch)
+    rows = [
+        {"id": "good", "timestamp": 1, "pnl": 1.0},
+        {"timestamp": 2, "pnl": 2.0},  # missing id
+        {"id": "bad2", "timestamp": 3, "pnl": "bad"},  # pnl not float
+    ]
+    traces = validate_traces(rows)
+    assert len(traces) == 1
+    assert traces[0].id == "good"
+    assert counter._value.get() == 2.0


### PR DESCRIPTION
## Summary
- add new Trace schema & `validate_traces`
- count trace validation failures via `metrics.trace_validation_fail_total`
- validate recent traces in `fetch_recent_traces`
- test validation helper for good and bad rows

## Testing
- `PYTHONPATH=src mypy -p dgm_kernel`
- `pytest -q tests/dgm_kernel_tests/test_trace_schema.py`

------
https://chatgpt.com/codex/tasks/task_e_686814d79e10832fa1fcbac6f7204536