### PR TITLE
feat(dgm): global pydantic strict mode

### DIFF
--- a/src/dgm_kernel/__init__.py
+++ b/src/dgm_kernel/__init__.py
@@ -5,6 +5,12 @@ Public re-exports so legacy tests like
 
 from importlib import import_module as _im
 
+from pydantic import BaseModel, ConfigDict
+
+# ──────────────────────── global settings ────────────────────────────
+# Apply strict validation across all Pydantic models in this package.
+BaseModel.model_config = ConfigDict(strict=True, extra="forbid")
+
 for _name in ("prover", "meta_loop", "sandbox", "hitl_pr"):
     try:
         globals()[_name] = _im(f".{_name}", __name__)

--- a/src/dgm_kernel/trace_schema.py
+++ b/src/dgm_kernel/trace_schema.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import List
 
-from pydantic import BaseModel, ConfigDict, ValidationError
+from pydantic import BaseModel, ValidationError
 
 from dgm_kernel import metrics
 
@@ -17,8 +17,6 @@ class Trace(BaseModel):
     timestamp: int
     pnl: float
     patch_id: str | None = None
-
-    model_config = ConfigDict(extra="ignore")
 
 
 def validate_traces(traces: List[dict]) -> List[Trace]:

--- a/tests/dgm_kernel_tests/test_pydantic_strict.py
+++ b/tests/dgm_kernel_tests/test_pydantic_strict.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+import dgm_kernel  # noqa:F401 - triggers global config
+from dgm_kernel.trace_schema import Trace
+
+
+def test_trace_extra_field_raises():
+    with pytest.raises(ValidationError):
+        Trace(id="t1", timestamp=0, pnl=0.0, extra_field="x")
+


### PR DESCRIPTION
## Summary
- enable strict `BaseModel` configs on import of dgm_kernel
- drop per-model config in `Trace`
- add regression test for strict mode

## Testing
- `pytest -q tests/dgm_kernel_tests/test_pydantic_strict.py`

------
https://chatgpt.com/codex/tasks/task_e_68681ad7b920832f9fb9f0c7e374293d