### PR TITLE
feat(dgm): corpus-driven fuzzer (DGM-24)

### DIFF
--- a/src/dgm_kernel/mutation_fuzzer.py
+++ b/src/dgm_kernel/mutation_fuzzer.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import ast
+import copy
+import random
+from pathlib import Path
+from typing import List
+
+
+def load_corpus() -> list[str]:
+    """Return list of mutation snippets from ``corpus/mutations``."""
+    corpus_dir = Path(__file__).resolve().parents[2] / "corpus" / "mutations"
+    snippets: list[str] = []
+    for path in sorted(corpus_dir.glob("*.py")):
+        snippets.append(path.read_text())
+    return snippets
+
+
+class MutationFuzzer:
+    """Corpus-driven mutation fuzzer."""
+
+    def __init__(self) -> None:
+        self._corpus = load_corpus()
+
+    def fuzz_source(self, code: str) -> str:
+        """Return a mutated version of ``code`` that always parses."""
+        target_tree = ast.parse(code)
+        snippet_src = random.choice(self._corpus)
+        snippet_tree = ast.parse(snippet_src)
+
+        def stmt_size(stmt: ast.stmt) -> int:
+            return len(ast.unparse(stmt))
+
+        candidates = [s for s in snippet_tree.body if stmt_size(s) <= len(code)]
+        stmt = copy.deepcopy(
+            random.choice(candidates) if candidates else min(snippet_tree.body, key=stmt_size)
+        )
+
+        bodies: List[List[ast.stmt]] = []
+        for node in ast.walk(target_tree):
+            for attr in ("body", "orelse", "finalbody"):
+                val = getattr(node, attr, None)
+                if isinstance(val, list):
+                    bodies.append(val)
+        body_list = random.choice(bodies)
+        idx = random.randint(0, len(body_list))
+        body_list.insert(idx, stmt)
+
+        ast.fix_missing_locations(target_tree)
+        mutated = ast.unparse(target_tree)
+        if len(mutated) > 2 * len(code):
+            return code
+        ast.parse(mutated)
+        return mutated
+
+
+fuzzer = MutationFuzzer()

--- a/tests/dgm_kernel_tests/test_fuzzer.py
+++ b/tests/dgm_kernel_tests/test_fuzzer.py
@@ -1,0 +1,14 @@
+import ast
+
+from dgm_kernel.mutation_fuzzer import fuzzer, load_corpus
+
+
+def test_fuzzer_parsable_and_size() -> None:
+    base = load_corpus()[0]
+    out: list[str] = []
+    for _ in range(100):
+        mutated = fuzzer.fuzz_source(base)
+        ast.parse(mutated)
+        out.append(mutated)
+    avg = sum(len(s) for s in out) / len(out)
+    assert avg <= 2 * len(base)


### PR DESCRIPTION
## Summary
- add mutation fuzzer that splices snippets from corpus
- ensure fuzzed code remains parseable and not overly large
- test that the fuzzer preserves syntax and keeps size in bounds

## Testing
- `python -m pytest -q tests/dgm_kernel_tests/test_fuzzer.py`
- `python -m mypy --strict src/dgm_kernel/mutation_fuzzer.py`


------
https://chatgpt.com/codex/tasks/task_e_68681f624304832f957782976086cb2d