### PR TITLE
feat(dgm): sandbox resource metrics (DGM-26)

### DIFF
--- a/src/dgm_kernel/metrics.py
+++ b/src/dgm_kernel/metrics.py
@@ -34,6 +34,17 @@ patch_apply_minutes_average = Gauge(
     "Average minutes between patch applications over the last 10 patches",
 )
 
+# Tracks total CPU time and RAM usage consumed by sandbox executions
+sandbox_cpu_ms_total = Counter(
+    "dgm_sandbox_cpu_ms_total",
+    "Total CPU milliseconds consumed by sandboxed patches",
+)
+
+sandbox_ram_mb_total = Counter(
+    "dgm_sandbox_ram_mb_total",
+    "Total RAM megabytes consumed by sandboxed patches",
+)
+
 _counters: Dict[CollectorRegistry, Dict[str, Counter]] = {}
 
 

--- a/tests/dgm_kernel_tests/test_sandbox_metrics.py
+++ b/tests/dgm_kernel_tests/test_sandbox_metrics.py
@@ -1,0 +1,49 @@
+import types
+from prometheus_client import CollectorRegistry, Counter
+import subprocess
+import resource
+
+from dgm_kernel import sandbox, metrics
+
+
+class DummyProc:
+    def __init__(self, rc: int = 0) -> None:
+        self.stdout = ""
+        self.stderr = ""
+        self.returncode = rc
+
+
+def test_run_patch_records_metrics(monkeypatch):
+    registry = CollectorRegistry(auto_describe=True)
+    cpu_counter = Counter(
+        "dgm_sandbox_cpu_ms_total",
+        "Total CPU ms",
+        registry=registry,
+    )
+    ram_counter = Counter(
+        "dgm_sandbox_ram_mb_total",
+        "Total RAM mb",
+        registry=registry,
+    )
+    monkeypatch.setattr(metrics, "sandbox_cpu_ms_total", cpu_counter)
+    monkeypatch.setattr(metrics, "sandbox_ram_mb_total", ram_counter)
+
+    # Fake subprocess.run
+    monkeypatch.setattr(sandbox, "subprocess", types.SimpleNamespace(run=lambda *a, **k: DummyProc()))
+
+    ru_vals = [
+        types.SimpleNamespace(ru_utime=1.0, ru_stime=1.0, ru_maxrss=1000),
+        types.SimpleNamespace(ru_utime=2.5, ru_stime=2.5, ru_maxrss=3000),
+    ]
+    def fake_getrusage(who):
+        return ru_vals.pop(0)
+    monkeypatch.setattr(sandbox.resource, "getrusage", fake_getrusage)
+
+    ok, logs, code, cpu_ms, ram_mb = sandbox.run_patch_in_sandbox({"after": "print('hi')"})
+
+    assert ok is True
+    assert cpu_ms == ( (2.5+2.5) - (1.0+1.0) ) * 1000.0
+    assert ram_mb == (3000 - 1000) / 1024.0
+    assert cpu_counter._value.get() == cpu_ms
+    assert ram_counter._value.get() == ram_mb
+


### PR DESCRIPTION
## Summary
- measure CPU/RAM for sandbox runs
- expose counters for CPU ms and RAM mb
- new tests for sandbox metrics

## Testing
- `pytest tests/dgm_kernel_tests -q`
- `PYTHONPATH=src mypy -p dgm_kernel`

------
https://chatgpt.com/codex/tasks/task_e_68681f729188832fa29aaf7c57bca5e7