### PR TITLE
feat(dgm): history CLI (DGM-27)

### DIFF
--- a/src/dgm_kernel/__main__.py
+++ b/src/dgm_kernel/__main__.py
@@ -9,6 +9,11 @@ from . import meta_loop
 def main() -> None:
     logging.basicConfig(level=logging.INFO)
     parser = argparse.ArgumentParser(description="DGM Kernel")
+    sub = parser.add_subparsers(dest="command")
+
+    history = sub.add_parser("history", help="Show patch history")
+    history.add_argument("--last", type=int, default=10, help="Show last N entries")
+
     parser.add_argument(
         "--once",
         action="store_true",
@@ -22,14 +27,18 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    if args.command == "history":
+        from . import cli_history
+
+        cli_history.main(["--last", str(args.last)])
+        return
+
     if args.once:
         logging.getLogger(__name__).info("Running DGM meta-loop once.")
         asyncio.run(meta_loop.loop_once())
         logging.getLogger(__name__).info("DGM meta-loop (once) finished.")
     elif args.forever:
-        logging.getLogger(__name__).info(
-            "Starting DGM meta-loop to run continuously."
-        )
+        logging.getLogger(__name__).info("Starting DGM meta-loop to run continuously.")
         asyncio.run(meta_loop.meta_loop())
 
 

--- a/src/dgm_kernel/cli_history.py
+++ b/src/dgm_kernel/cli_history.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from .patch_cli import PATCH_HISTORY_FILE
+
+
+@click.command()
+@click.option("--last", "last", default=10, show_default=True, type=int)
+def main(last: int) -> None:
+    """Display recent patch history."""
+    if not PATCH_HISTORY_FILE.exists():
+        click.echo("No patch history found", err=True)
+        raise SystemExit(1)
+
+    history = json.loads(PATCH_HISTORY_FILE.read_text())
+    entries = history[-last:]
+
+    table = Table(box=None)
+    for col in ("id", "ts", "reward", "lines_changed"):
+        table.add_column(col)
+
+    for entry in entries:
+        table.add_row(
+            str(entry.get("patch_id", "")),
+            str(entry.get("timestamp", "")),
+            str(entry.get("reward", "")),
+            str(entry.get("lines_changed", "")),
+        )
+
+    Console(color_system=None).print(table)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual CLI usage
+    main()

--- a/tests/dgm_kernel_tests/test_history_cli.py
+++ b/tests/dgm_kernel_tests/test_history_cli.py
@@ -1,0 +1,31 @@
+import json
+from pathlib import Path
+from click.testing import CliRunner
+
+from dgm_kernel import cli_history
+
+
+def _make_history(path: Path, n: int) -> None:
+    entries = []
+    for i in range(n):
+        entries.append(
+            {
+                "patch_id": f"p{i}",
+                "timestamp": i,
+                "reward": float(i),
+                "lines_changed": i + 1,
+            }
+        )
+    path.write_text(json.dumps(entries))
+
+
+def test_history_table_header(tmp_path, monkeypatch):
+    history_file = tmp_path / "history.json"
+    _make_history(history_file, 3)
+    monkeypatch.setattr(cli_history, "PATCH_HISTORY_FILE", history_file)
+
+    runner = CliRunner()
+    result = runner.invoke(cli_history.main, ["--last", "2"])
+    assert result.exit_code == 0, result.output
+    first = result.output.splitlines()[0].split()
+    assert first == ["id", "ts", "reward", "lines_changed"]


### PR DESCRIPTION
## Summary
- implement `cli_history` with simple table output
- add `history` command to `dgm_kernel.__main__`
- test history CLI

## Testing
- `pytest -q tests/dgm_kernel_tests/test_history_cli.py`
- `pytest -q tests/dgm_kernel_tests`

------
https://chatgpt.com/codex/tasks/task_e_68681f79d148832fab71a4963f4cb099