### PR TITLE
feat(dgm): OpenTelemetry spans (DGM-28)

### DIFF
--- a/requirements-dgm-tests.txt
+++ b/requirements-dgm-tests.txt
@@ -8,3 +8,5 @@ fakeredis>=2.19
 prometheus-client
 requests>=2
 psutil
+opentelemetry-api
+opentelemetry-sdk

--- a/src/dgm_kernel/meta_loop.py
+++ b/src/dgm_kernel/meta_loop.py
@@ -33,6 +33,7 @@ from dgm_kernel.prover import _get_pylint_score as _prover_pylint_score
 from dgm_kernel.prover import prove_patch
 from dgm_kernel.sandbox import run_patch_in_sandbox
 from llm_sidecar.reward import proofable_reward
+from dgm_kernel.otel import tracer
 
 # ─────────────────────────────── globals & config ────────────────────────────
 log = logging.getLogger(__name__)
@@ -318,43 +319,48 @@ def _record_patch_history(entry: dict[str, Any]) -> None:
 
 # ───────────────────────────── one-shot & forever loops ─────────────────────
 async def loop_once() -> None:
-    traces = await fetch_recent_traces()
-    if not traces:
-        return
+    with tracer.start_as_current_span("meta_loop.iteration"):
+        with tracer.start_as_current_span("fetch_traces"):
+            traces = await fetch_recent_traces()
+        if not traces:
+            return
 
-    patch = await generate_patch(traces)
-    if not patch or not await _verify_patch(traces, patch):
-        return
+        with tracer.start_as_current_span("generate_patch"):
+            patch = await generate_patch(traces)
+        with tracer.start_as_current_span("verify_patch"):
+            if not patch or not await _verify_patch(traces, patch):
+                return
 
-    diff = "\n".join(
-        difflib.unified_diff(
-            patch["before"].splitlines(),
-            patch["after"].splitlines(),
-            fromfile="before",
-            tofile="after",
-            lineterm="",
+        diff = "\n".join(
+            difflib.unified_diff(
+                patch["before"].splitlines(),
+                patch["after"].splitlines(),
+                fromfile="before",
+                tofile="after",
+                lineterm="",
+            )
         )
-    )
-    if prove_patch(diff) < 0.8:
-        return
+        if prove_patch(diff) < 0.8:
+            return
 
-    ok, _, exit_code = run_patch_in_sandbox(patch)
-    if not ok:
-        return
+        with tracer.start_as_current_span("sandbox"):
+            ok, _, exit_code = run_patch_in_sandbox(patch)
+        if not ok:
+            return
 
-    if time.time() - _last_patch_time < PATCH_RATE_LIMIT_SECONDS:
-        return
+        if time.time() - _last_patch_time < PATCH_RATE_LIMIT_SECONDS:
+            return
 
-    _apply_patch(patch)
-    _record_patch_history(
-        {
-            "patch_id": str(uuid.uuid4()),
-            "timestamp": time.time(),
-            "diff": diff,
-            "reward": 0.0,
-            "sandbox_exit_code": exit_code,
-        }
-    )
+        _apply_patch(patch)
+        _record_patch_history(
+            {
+                "patch_id": str(uuid.uuid4()),
+                "timestamp": time.time(),
+                "diff": diff,
+                "reward": 0.0,
+                "sandbox_exit_code": exit_code,
+            }
+        )
 
 
 async def meta_loop() -> None:

--- a/src/dgm_kernel/otel.py
+++ b/src/dgm_kernel/otel.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _setup_tracer() -> Any:
+    """Return a global tracer named 'dgm', fallback to no-op if unavailable."""
+    try:  # pragma: no cover - optional dependency
+        from opentelemetry import trace as ot_trace
+    except Exception:
+        logger.info("OpenTelemetry not available; spans disabled.")
+
+        class _DummySpan:
+            def __enter__(self) -> None:
+                return None
+
+            def __exit__(self, exc_type, exc, tb) -> bool:
+                return False
+
+        class _DummyTracer:
+            def start_as_current_span(self, _name: str) -> _DummySpan:
+                return _DummySpan()
+
+        return _DummyTracer()
+
+    return ot_trace.get_tracer("dgm")
+
+
+tracer = _setup_tracer()

--- a/tests/dgm_kernel_tests/test_otel.py
+++ b/tests/dgm_kernel_tests/test_otel.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+from opentelemetry import trace
+import sys
+import types
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+
+def _setup_tracing() -> InMemorySpanExporter:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    return exporter
+
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_loop_once_spans(monkeypatch):
+    exporter = _setup_tracing()
+    # import after tracer provider configured
+    dummy_crypto = types.ModuleType("dgm_kernel.crypto_sign")
+    dummy_crypto.sign_patch = lambda diff: "sig"
+    dummy_crypto.verify_patch = lambda diff, sig: True
+    sys.modules["dgm_kernel.crypto_sign"] = dummy_crypto
+
+    from dgm_kernel import meta_loop
+
+    monkeypatch.setattr(meta_loop, "PATCH_RATE_LIMIT_SECONDS", 0, raising=False)
+    monkeypatch.setattr(meta_loop, "_last_patch_time", 0.0, raising=False)
+    monkeypatch.setattr(meta_loop, "fetch_recent_traces", AsyncMock(return_value=[{"id": "t1"}]))
+    monkeypatch.setattr(meta_loop, "generate_patch", AsyncMock(return_value={"target": "t.py", "before": "", "after": ""}))
+    monkeypatch.setattr(meta_loop, "_verify_patch", AsyncMock(return_value=True))
+    monkeypatch.setattr(meta_loop, "prove_patch", lambda diff: 1.0)
+    monkeypatch.setattr(meta_loop, "run_patch_in_sandbox", lambda patch: (True, "", 0))
+    monkeypatch.setattr(meta_loop, "_apply_patch", lambda patch: True)
+    monkeypatch.setattr(meta_loop, "_record_patch_history", lambda entry: None)
+
+    await meta_loop.loop_once()
+
+    names = {s.name for s in exporter.get_finished_spans()}
+    assert names == {"meta_loop.iteration", "fetch_traces", "generate_patch", "verify_patch", "sandbox"}
+
+
+


### PR DESCRIPTION
## Summary
- add OpenTelemetry helper in `dgm_kernel.otel`
- instrument `loop_once` with tracing spans
- support otel deps in dgm test requirements
- test spans via in-memory exporter

## Testing
- `pytest tests/dgm_kernel_tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68681f80b8c8832fb2273f7ad1ee660b