### PR TITLE
chore(dev): deduplicate mypy.ini sections & silence missing stubs (DGM-21)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -7,20 +7,35 @@ mypy_path = src              # src-layout root
 ###############################################################################
 # 3rd-party & external libs – ignore if stubs are missing
 ###############################################################################
-[mypy-requests.*]            ignore_missing_imports = True
-[mypy-github.*]              ignore_missing_imports = True
-[mypy-lancedb.*]             ignore_missing_imports = True
-[mypy-llm_sidecar.*]         ignore_missing_imports = True
-
-# scientific / test helpers
-[mypy-pydantic.*]            ignore_missing_imports = True
-[mypy-pydantic_core.*]       ignore_missing_imports = True
-[mypy-hypothesis.*]          ignore_missing_imports = True
-[mypy-pytest.*]              ignore_missing_imports = True
+[mypy-requests.*]
+ignore_missing_imports = True
+ignore_errors = True
 
 [mypy-github.*]
+ignore_missing_imports = True
 ignore_errors = True
 
 [mypy-lancedb.*]
+ignore_missing_imports = True
 ignore_errors = True
 
+[mypy-llm_sidecar.*]
+ignore_missing_imports = True
+ignore_errors = True
+
+# scientific / test helpers
+[mypy-pydantic.*]
+ignore_missing_imports = True
+ignore_errors = True
+
+[mypy-pydantic_core.*]
+ignore_missing_imports = True
+ignore_errors = True
+
+[mypy-hypothesis.*]
+ignore_missing_imports = True
+ignore_errors = True
+
+[mypy-pytest.*]
+ignore_missing_imports = True
+ignore_errors = True


### PR DESCRIPTION
## Summary
- de-duplicate mypy.ini headers
- add `ignore_errors` alongside `ignore_missing_imports` for third party stanzas

## Testing
- `python -m mypy --strict ./src/dgm_kernel`
- `python -m mypy --strict -p dgm_kernel` *(fails to find package)*

------
https://chatgpt.com/codex/tasks/task_e_68685a5bb73c832f8eb7661da015b3ac