### PR TITLE
fix(dgm): correct indentation & registry export in mutation_strategies (DGM-20)

### DIFF
--- a/src/dgm_kernel/otel.py
+++ b/src/dgm_kernel/otel.py
@@ -1,4 +1,4 @@
-from __future__ in annotations
+from __future__ import annotations
 
 import logging
 from typing import Any, Literal, Type


### PR DESCRIPTION
## Summary
- fix indentation bug in `mutation_strategies`
- expose `DEFAULT_REGISTRY` and export mutation helpers
- return a class from `choose_mutation`
- fix syntax error in `otel` so tests import cleanly

## Testing
- `pytest -q tests/dgm_kernel_tests/test_ab_mutator.py tests/dgm_kernel_tests/test_fuzzer.py tests/dgm_kernel_tests/test_mutation_strategies.py`
- `python -m mypy --config-file /tmp/tmp_mypy.ini -m dgm_kernel.mutation_strategies`
- `python -m mypy --config-file /tmp/tmp_mypy.ini -p dgm_kernel` *(fails: several missing stubs)*

------
https://chatgpt.com/codex/tasks/task_e_68685a51bb30832fa1abe6bac2c93e9f