### PR TITLE
feat(dgm): local LanceDB stub & typed harvest_feedback (DGM-22)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -8,8 +8,12 @@ mypy_path = src              # src-layout root
 # 3rd-party & external libs – ignore if stubs are missing
 ###############################################################################
 [mypy-requests.*]            ignore_missing_imports = True
-[mypy-github.*]              ignore_missing_imports = True
-[mypy-lancedb.*]             ignore_missing_imports = True
+[mypy-github.*]
+ignore_missing_imports = True
+ignore_errors = True
+[mypy-lancedb.*]
+ignore_missing_imports = True
+ignore_errors = True
 [mypy-llm_sidecar.*]         ignore_missing_imports = True
 
 # scientific / test helpers
@@ -18,9 +22,4 @@ mypy_path = src              # src-layout root
 [mypy-hypothesis.*]          ignore_missing_imports = True
 [mypy-pytest.*]              ignore_missing_imports = True
 
-[mypy-github.*]
-ignore_errors = True
-
-[mypy-lancedb.*]
-ignore_errors = True
 

--- a/src/dgm_kernel/mutation_strategies.py
+++ b/src/dgm_kernel/mutation_strategies.py
@@ -71,9 +71,8 @@ def weighted_choice(strategies: list[MutationStrategy]) -> MutationStrategy:
     from dgm_kernel import metrics
 
     registry: CollectorRegistry = metrics.DEFAULT_REGISTRY
-__all__ = ["MutationStrategy", "DEFAULT_REGISTRY"]
-weights = []
-for strat in strategies:
+    weights = []
+    for strat in strategies:
         succ = (
             registry.get_sample_value(
                 "dgm_mutation_success_total", labels={"strategy": strat.name}

--- a/src/dgm_kernel/otel.py
+++ b/src/dgm_kernel/otel.py
@@ -1,4 +1,4 @@
-from __future__ in annotations
+from __future__ import annotations
 
 import logging
 from typing import Any, Literal, Type


### PR DESCRIPTION
## Summary
- provide a minimal LanceDB stub for local type-checking
- clean up MyPy config
- type annotate harvest_feedback and add helper for existing rows
- fix typos in otel module
- tidy mutation strategy loop

## Testing
- `pytest -q tests/dgm_kernel_tests/test_harvest.py`


------
https://chatgpt.com/codex/tasks/task_e_68685a6f6bc4832f87ff835e5a08e34a