### PR TITLE
fix(dgm): robust draft_patch & types (DGM-23)

### DIFF
--- a/tests/dgm_kernel_tests/test_llm_client.py
+++ b/tests/dgm_kernel_tests/test_llm_client.py
@@ -6,6 +6,7 @@ import pytest
 
 from dgm_kernel import llm_client
 from dgm_kernel.config import ExternalLLMConfig
+from dgm_kernel.trace_schema import Trace
 
 
 class DummyResponse:
@@ -25,7 +26,8 @@ def test_draft_patch_success(monkeypatch: pytest.MonkeyPatch) -> None:
     post_mock = mock.Mock(return_value=resp)
     monkeypatch.setattr(llm_client.requests, "post", post_mock)
 
-    result = llm_client.draft_patch([{"foo": "bar"}])
+    trace = Trace(id="1", timestamp=1, pnl=0.0)
+    result = llm_client.draft_patch([trace])
     assert result == expected
     post_mock.assert_called_once()
 
@@ -36,6 +38,7 @@ def test_draft_patch_bad_status(monkeypatch: pytest.MonkeyPatch) -> None:
     post_mock = mock.Mock(return_value=resp)
     monkeypatch.setattr(llm_client.requests, "post", post_mock)
 
-    result = llm_client.draft_patch([{"foo": "bar"}])
+    trace = Trace(id="1", timestamp=1, pnl=0.0)
+    result = llm_client.draft_patch([trace])
     assert result is None
     post_mock.assert_called_once()


### PR DESCRIPTION
## Summary
- handle LLM request failures in `draft_patch`
- encode traces as JSON strings before posting
- update tests for new behaviour

## Testing
- `pytest -q tests/dgm_kernel_tests/test_llm_client.py`
- `PYTHONPATH=src mypy --strict -m dgm_kernel.llm_client`


------
https://chatgpt.com/codex/tasks/task_e_686860653a64832fbe071f1a4c60446a