### PR TITLE
fix(dgm): fix weighted_choice & export registry (DGM-22)

### DIFF
--- a/src/dgm_kernel/__init__.py
+++ b/src/dgm_kernel/__init__.py
@@ -5,7 +5,7 @@ Public re-exports so legacy tests like
 
 from importlib import import_module as _im
 
-for _name in ("prover", "meta_loop", "sandbox", "hitl_pr"):
+for _name in ("prover", "meta_loop", "sandbox", "hitl_pr", "metrics"):
     try:
         globals()[_name] = _im(f".{_name}", __name__)
     except ModuleNotFoundError:

--- a/tests/dgm_kernel_tests/test_strategy_picker.py
+++ b/tests/dgm_kernel_tests/test_strategy_picker.py
@@ -37,7 +37,7 @@ def test_weighted_choice_distribution(monkeypatch: pytest.MonkeyPatch) -> None:
     for _ in range(80):
         metrics.increment_mutation_failure(strategy="ASTRenameIdentifier", registry=registry)
 
-    strategies = [ASTInsertComment(), ASTRenameIdentifier()]
+    strategies = [ASTInsertComment, ASTRenameIdentifier]
     counts: Counter[str] = Counter()
     random.seed(0)
     for _ in range(1000):


### PR DESCRIPTION
## Summary
- export metrics in dgm_kernel package
- update `weighted_choice` to operate on classes
- clean up registry helper
- adjust strategy picker test

## Testing
- `pytest -q tests/dgm_kernel_tests/test_{ab_mutator,fuzzer,mutation_strategies,strategy_picker}.py`
- `PYTHONPATH=$PWD/src mypy --strict -m dgm_kernel.mutation_strategies`


------
https://chatgpt.com/codex/tasks/task_e_6868605dc5d0832fa0a5a373b9c6f458