### PR TITLE
fix(dgm): dict-based traces & sandbox unpack (DGM-24)

### DIFF
--- a/src/dgm_kernel/trace_schema.py
+++ b/src/dgm_kernel/trace_schema.py
@@ -31,6 +31,10 @@ class Trace(BaseModel):
 
     model_config = ConfigDict(extra="ignore")
 
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain dictionary representation of the trace."""
+        return self.model_dump()
+
 
 def validate_traces(traces: list[dict[str, Any]]) -> list[Trace]:
     """Validate raw trace dicts, dropping invalid rows."""
@@ -49,4 +53,4 @@ def validate_traces(traces: list[dict[str, Any]]) -> list[Trace]:
     return valid
 
 
-__all__ = ["Trace", "validate_traces", "HistoryEntry"]
+__all__ = ["validate_traces", "HistoryEntry"]


### PR DESCRIPTION
## Summary
- convert `fetch_recent_traces` to return dictionaries
- add `Trace.to_dict` helper and keep model internal
- adapt meta loop to new trace format and sandbox return

## Testing
- `pytest -q tests/dgm_kernel_tests/test_meta_loop.py tests/dgm_kernel_tests/test_otel.py`
- `MYPYPATH=src mypy --strict -p dgm_kernel.trace_schema`

------
https://chatgpt.com/codex/tasks/task_e_6868609dcec0832fbde13027bb6915b3