### PR TITLE
feat(dgm): adaptive mutation weights with exponential decay (DGM-29)

### DIFF
--- a/src/dgm_kernel/pr_bot.py
+++ b/src/dgm_kernel/pr_bot.py
@@ -24,7 +24,7 @@ def main() -> None:
         return
 
     try:
-        from github import Github  # type: ignore
+        from github import Github
     except Exception as exc:  # pragma: no cover - optional dependency
         log.error("PyGithub not available: %s", exc)
         return


### PR DESCRIPTION
## Summary
- add DECAY constant for weighting
- update `weighted_choice` to apply exponential decay
- fix a mypy unused-ignore in pr_bot
- test that weight distribution drifts toward uniform over time

## Testing
- `pytest -q tests/dgm_kernel_tests/test_strategy_picker.py`
- `PYTHONPATH=$PWD/src mypy --strict -p dgm_kernel`


------
https://chatgpt.com/codex/tasks/task_e_68686ddfd038832f9999930efb5adea5