### PR TITLE
feat(dgm): adaptive sandbox timeout based on recent runtimes (DGM-32)

### DIFF
--- a/src/dgm_kernel/metrics.py
+++ b/src/dgm_kernel/metrics.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
 from typing import Dict, List, Optional
-from prometheus_client import Counter, Gauge, CollectorRegistry, REGISTRY as DEFAULT_REGISTRY
+from prometheus_client import (
+    Counter,
+    Gauge,
+    Histogram,
+    CollectorRegistry,
+    REGISTRY as DEFAULT_REGISTRY,
+)
 
 _PATCH_APPLIED = "dgm_patches_applied_total"
 _PATCH_GENERATION = "dgm_patch_generation_total"
@@ -45,6 +51,13 @@ sandbox_cpu_ms_total = Counter(
 sandbox_ram_mb_total = Counter(
     "dgm_sandbox_ram_mb_total",
     "Total RAM megabytes consumed by sandboxed patches",
+)
+
+# Histogram of sandbox runtime durations
+sandbox_runtime_seconds = Histogram(
+    "dgm_sandbox_runtime_seconds",
+    "Runtime of successful sandbox executions in seconds",
+    buckets=(0.1, 0.3, 1.0, 3.0, 10.0, 30.0),
 )
 
 _counters: Dict[CollectorRegistry, Dict[str, Counter]] = {}

--- a/src/dgm_kernel/pr_bot.py
+++ b/src/dgm_kernel/pr_bot.py
@@ -24,7 +24,7 @@ def main() -> None:
         return
 
     try:
-        from github import Github  # type: ignore
+        from github import Github
     except Exception as exc:  # pragma: no cover - optional dependency
         log.error("PyGithub not available: %s", exc)
         return

--- a/tests/dgm_kernel_tests/test_sandbox_metrics.py
+++ b/tests/dgm_kernel_tests/test_sandbox_metrics.py
@@ -1,7 +1,13 @@
 import types
-from prometheus_client import CollectorRegistry, Counter
+from prometheus_client import CollectorRegistry, Counter, Histogram
 import subprocess
 import resource
+import statistics
+from collections import defaultdict
+from unittest.mock import AsyncMock
+import pytest
+
+from dgm_kernel import meta_loop
 
 from dgm_kernel import sandbox, metrics
 
@@ -11,6 +17,34 @@ class DummyProc:
         self.stdout = ""
         self.stderr = ""
         self.returncode = rc
+
+
+class _MiniRedis:
+    """Simple in-memory Redis subset."""
+
+    def __init__(self) -> None:
+        self._data: dict[str, list[str]] = defaultdict(list)
+
+    def lpush(self, key: str, val: str) -> None:
+        self._data[key].insert(0, val)
+
+    def lrange(self, key: str, start: int, end: int) -> list[str]:
+        lst = self._data[key]
+        if end == -1:
+            end = len(lst) - 1
+        return lst[start : end + 1]
+
+    def ltrim(self, key: str, start: int, end: int) -> None:
+        lst = self._data[key]
+        if end == -1:
+            end = len(lst) - 1
+        self._data[key] = lst[start : end + 1]
+
+    def llen(self, key: str) -> int:
+        return len(self._data[key])
+
+    def ping(self) -> bool:
+        return True
 
 
 def test_run_patch_records_metrics(monkeypatch):
@@ -46,4 +80,86 @@ def test_run_patch_records_metrics(monkeypatch):
     assert ram_mb == (3000 - 1000) / 1024.0
     assert cpu_counter._value.get() == cpu_ms
     assert ram_counter._value.get() == ram_mb
+
+
+def test_timeout_helpers(monkeypatch):
+    redis_stub = _MiniRedis()
+    monkeypatch.setattr(sandbox, "REDIS", redis_stub)
+
+    registry = CollectorRegistry(auto_describe=True)
+    hist = Histogram(
+        "dgm_sandbox_runtime_seconds",
+        "Runtime",
+        buckets=(0.1, 0.3, 1, 3, 10, 30),
+        registry=registry,
+    )
+    monkeypatch.setattr(metrics, "sandbox_runtime_seconds", hist)
+    monkeypatch.setattr(sandbox.metrics, "sandbox_runtime_seconds", hist)
+
+    samples = [1.0, 2.0, 3.0, 4.0, 5.0]
+    for s in samples:
+        sandbox.record_runtime(s)
+
+    expected = max(10.0, 4 * statistics.median(samples))
+    assert sandbox.suggest_timeout() == pytest.approx(expected)
+    assert redis_stub.llen(sandbox.RUNTIMES_KEY) == len(samples)
+
+
+@pytest.mark.asyncio
+async def test_meta_loop_records_runtime(monkeypatch):
+    redis_stub = _MiniRedis()
+    monkeypatch.setattr(sandbox, "REDIS", redis_stub)
+
+    registry = CollectorRegistry(auto_describe=True)
+    hist = Histogram(
+        "dgm_sandbox_runtime_seconds",
+        "Runtime",
+        buckets=(0.1, 0.3, 1, 3, 10, 30),
+        registry=registry,
+    )
+    monkeypatch.setattr(metrics, "sandbox_runtime_seconds", hist)
+    monkeypatch.setattr(sandbox.metrics, "sandbox_runtime_seconds", hist)
+    monkeypatch.setattr(meta_loop.metrics, "sandbox_runtime_seconds", hist)
+
+    monkeypatch.setattr(meta_loop, "PATCH_RATE_LIMIT_SECONDS", 0, raising=False)
+    monkeypatch.setattr(meta_loop, "_last_patch_time", 0.0, raising=False)
+    monkeypatch.setattr(meta_loop, "_apply_patch", lambda patch: True)
+    monkeypatch.setattr(meta_loop, "_record_patch_history", lambda entry: None)
+    monkeypatch.setattr(meta_loop, "prove_patch", lambda diff: 1.0)
+
+    monkeypatch.setattr(meta_loop, "fetch_recent_traces", AsyncMock(return_value=[{}]))
+    monkeypatch.setattr(
+        meta_loop,
+        "generate_patch",
+        AsyncMock(return_value={"target": "t.py", "before": "", "after": ""}),
+    )
+    monkeypatch.setattr(meta_loop, "_verify_patch", AsyncMock(return_value=True))
+
+    monkeypatch.setattr(meta_loop, "suggest_timeout", lambda default=10.0: 2.0)
+    tvals = [1.0, 3.0]
+
+    def fake_perf() -> float:
+        return tvals.pop(0)
+
+    monkeypatch.setattr(meta_loop.time, "perf_counter", fake_perf)
+
+    call = {}
+
+    def fake_run(patch, timeout=None):
+        call["timeout"] = timeout
+        return True, "", 0, 0.0, 0.0
+
+    monkeypatch.setattr(meta_loop, "run_patch_in_sandbox", fake_run)
+
+    rec = {}
+
+    def fake_record(dur: float) -> None:
+        rec["dur"] = dur
+
+    monkeypatch.setattr(meta_loop, "record_runtime", fake_record)
+
+    await meta_loop.loop_once()
+
+    assert call["timeout"] == 2.0
+    assert rec["dur"] == pytest.approx(2.0)
 


### PR DESCRIPTION
## Summary
- add sandbox runtime recording and timeout suggestion via Redis
- expose runtime histogram metric
- adapt meta-loop sandbox call to use adaptive timeout and record durations
- update PR bot to use typed PyGithub
- extend sandbox metrics tests for timeout logic

## Testing
- `pytest -q tests/dgm_kernel_tests/test_sandbox_metrics.py`
- `PYTHONPATH=$PWD/src mypy --strict -p dgm_kernel`

------
https://chatgpt.com/codex/tasks/task_e_68686de54000832f92f974facd517786