### PR TITLE
feat(router): add speech text topic & helper (DGM-34)

### DIFF
--- a/src/llm_sidecar/event_bus.py
+++ b/src/llm_sidecar/event_bus.py
@@ -1,22 +1,69 @@
-"""Async EventBus stub for unit tests."""
-from typing import AsyncIterator, Any
+"""Minimal async EventBus used in the test-suite."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from dataclasses import asdict
+from enum import Enum
+from typing import Any, AsyncIterator, Dict, List
+
+from pydantic import Field
+from pydantic.dataclasses import dataclass
+
 
 class RedisError(Exception):
-    pass
+    """Placeholder Redis error used by the stub."""
 
-class EventBus:  # no behaviours needed for tests
-    async def publish(self, *_, **__):
-        return None
-    async def subscribe(self, *_, **__) -> AsyncIterator[Any]:
-        yield {}
 
-aSYNC_EMPTY: AsyncIterator[Any]
+class Channel(str, Enum):
+    """Event bus topics."""
 
-async def connect(*_, **__):  # noqa: D401
+    SPEECH_TEXT = "speech.text"  # Whisper → Router
+    TTS_TEXT = "speech.tts"  # Router → TTS
+
+
+@dataclass
+class SpeechMessage:
+    """Payload published on :pydata:`Channel.SPEECH_TEXT`."""
+
+    text: str
+    ts: float = Field(default_factory=time.time)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class EventBus:
+    """Very small in-memory publish/subscribe helper."""
+
+    def __init__(self) -> None:
+        self._subs: Dict[str, List[asyncio.Queue[str]]] = {}
+
+    async def publish(self, channel: str, payload: str) -> None:
+        for q in list(self._subs.get(channel, [])):
+            await q.put(payload)
+
+    async def subscribe(self, channel: str) -> AsyncIterator[str]:
+        q: asyncio.Queue[str] = asyncio.Queue()
+        self._subs.setdefault(channel, []).append(q)
+        try:
+            while True:
+                yield await q.get()
+        finally:
+            self._subs.get(channel, []).remove(q)
+
+    async def publish_speech(self, text: str, **meta: Any) -> None:
+        msg = SpeechMessage(text=text, metadata=dict(meta))
+        await self.publish(Channel.SPEECH_TEXT.value, json.dumps(asdict(msg)))
+
+
+async def connect(*_: Any, **__: Any) -> EventBus:  # noqa: D401
     return EventBus()
 
-async def close(*_, **__):
+
+async def close(*_: Any, **__: Any) -> None:
     return None
 
-async def subscribe(*_, **__):
+
+async def subscribe(*_: Any, **__: Any) -> AsyncIterator[Any]:
     yield {}

--- a/tests/llm_sidecar_tests/test_event_bus.py
+++ b/tests/llm_sidecar_tests/test_event_bus.py
@@ -1,0 +1,28 @@
+import asyncio
+import json
+
+import pytest
+
+from llm_sidecar.event_bus import EventBus, Channel
+
+
+@pytest.mark.asyncio
+async def test_publish_subscribe_round_trip():
+    bus = EventBus()
+    received: list[str] = []
+
+    async def listener():
+        async for payload in bus.subscribe(Channel.SPEECH_TEXT.value):
+            received.append(payload)
+            break
+
+    task = asyncio.create_task(listener())
+    await asyncio.sleep(0)  # ensure listener starts
+    await bus.publish_speech("hello", foo="bar")
+    await asyncio.wait_for(task, timeout=1)
+
+    assert len(received) == 1
+    data = json.loads(received[0])
+    assert data["text"] == "hello"
+    assert data["metadata"] == {"foo": "bar"}
+    assert isinstance(data["ts"], float)


### PR DESCRIPTION
## Summary
- extend `event_bus` with `Channel` enum and `SpeechMessage`
- add `EventBus.publish_speech` helper
- unit test speech publish/subscribe

## Testing
- `pytest -q tests/llm_sidecar_tests/test_event_bus.py`
- `PYTHONPATH=src python -m mypy --strict src/llm_sidecar/event_bus.py`

------
https://chatgpt.com/codex/tasks/task_e_68687930b764832fbf9a82889e2dbea3