### PR TITLE
feat(router): YAML pattern intent matcher (DGM-35)

### DIFF
--- a/src/osiris/intent_patterns.yaml
+++ b/src/osiris/intent_patterns.yaml
@@ -1,0 +1,28 @@
+intents:
+  - name: TURN_LIGHT_ON
+    patterns:
+      - "turn on * light*"
+      - "lights on *"
+    route: ORCHESTRATOR
+  - name: TIMER_SET
+    patterns:
+      - "set a timer for *"
+      - "timer * minutes"
+    route: ORCHESTRATOR
+  - name: JOKE
+    patterns:
+      - "tell me a joke"
+      - "make me laugh"
+    route: ORCHESTRATOR
+  - name: GENERAL_QA
+    patterns:
+      - "who is *"
+      - "what is *"
+    route: ORCHESTRATOR
+  - name: QUICK_FACT
+    patterns:
+      - "give me a quick fact about *"
+    route: ORCHESTRATOR
+  - name: UNKNOWN
+    patterns: []
+    route: UNKNOWN

--- a/src/osiris/intent_router.py
+++ b/src/osiris/intent_router.py
@@ -1,0 +1,52 @@
+"""Pattern based intent matcher used for routing requests."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Tuple
+
+import yaml
+
+
+@dataclass
+class _Intent:
+    name: str
+    patterns: List[re.Pattern[str]]
+    route: str
+
+
+def _compile(pattern: str) -> re.Pattern[str]:
+    """Convert a simple glob pattern to a regular expression."""
+    regex = "^" + re.escape(pattern).replace("\\*", ".*") + "$"
+    return re.compile(regex, re.IGNORECASE)
+
+
+def _load_intents() -> List[_Intent]:
+    path = Path(__file__).with_name("intent_patterns.yaml")
+    data = yaml.safe_load(path.read_text()) or {}
+    items = data.get("intents", [])
+    intents: List[_Intent] = []
+    for item in items:
+        raw_patterns = item.get("patterns", [])
+        compiled = [_compile(p) for p in raw_patterns]
+        intents.append(
+            _Intent(name=item.get("name", "UNKNOWN"), patterns=compiled, route=item.get("route", "UNKNOWN"))
+        )
+    return intents
+
+
+_INTENTS: List[_Intent] = _load_intents()
+
+
+class IntentRouter:
+    """Match text against YAML patterns and suggest a routing target."""
+
+    @staticmethod
+    def get_intent(text: str) -> Tuple[str, str]:
+        for intent in _INTENTS:
+            for pattern in intent.patterns:
+                if pattern.search(text):
+                    return intent.name, intent.route
+        return "UNKNOWN", "UNKNOWN"

--- a/tests/osiris_tests/__init__.py
+++ b/tests/osiris_tests/__init__.py
@@ -1,0 +1,1 @@
+# Package for intent router tests

--- a/tests/osiris_tests/test_patterns.py
+++ b/tests/osiris_tests/test_patterns.py
@@ -1,0 +1,45 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_router() -> type:
+    path = Path(__file__).resolve().parents[2] / "src" / "osiris" / "intent_router.py"
+    spec = importlib.util.spec_from_file_location("intent_router", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module.IntentRouter
+
+IntentRouter = _load_router()
+
+
+def test_turn_light_on() -> None:
+    name, route = IntentRouter.get_intent("turn on the kitchen lights")
+    assert (name, route) == ("TURN_LIGHT_ON", "ORCHESTRATOR")
+
+
+def test_timer_set() -> None:
+    name, route = IntentRouter.get_intent("set a timer for 5 minutes")
+    assert (name, route) == ("TIMER_SET", "ORCHESTRATOR")
+
+
+def test_joke() -> None:
+    name, route = IntentRouter.get_intent("tell me a joke")
+    assert (name, route) == ("JOKE", "ORCHESTRATOR")
+
+
+def test_general_qa() -> None:
+    name, route = IntentRouter.get_intent("who is the president of France?")
+    assert (name, route) == ("GENERAL_QA", "ORCHESTRATOR")
+
+
+def test_quick_fact() -> None:
+    name, route = IntentRouter.get_intent("give me a quick fact about space")
+    assert (name, route) == ("QUICK_FACT", "ORCHESTRATOR")
+
+
+def test_unknown() -> None:
+    name, route = IntentRouter.get_intent("this does not match anything")
+    assert (name, route) == ("UNKNOWN", "UNKNOWN")


### PR DESCRIPTION
## Summary
- add sample intent patterns in YAML
- implement pattern-based router
- load router module directly in tests
- ensure intent routing unit tests

## Testing
- `pytest -q tests/osiris_tests/test_patterns.py`
- `mypy --strict src/osiris/intent_router.py`

------
https://chatgpt.com/codex/tasks/task_e_686879365cc0832fa895b0bf044f745a