### PR TITLE
feat(router): add dummy intent classifier interface (DGM-36)

### DIFF
--- a/src/osiris/intent_classifier.py
+++ b/src/osiris/intent_classifier.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class BaseClassifier(ABC):
+    """Abstract classifier interface."""
+
+    @abstractmethod
+    def predict(self, text: str) -> tuple[str, float]:
+        """Return a tuple of ``(intent, confidence)`` for the input ``text``."""
+        raise NotImplementedError
+
+
+class DummyClassifier(BaseClassifier):
+    """Very small keyword-based intent classifier."""
+
+    _keywords = {
+        "buy": "BUY",
+        "sell": "SELL",
+    }
+
+    def predict(self, text: str) -> tuple[str, float]:
+        lowered = text.lower()
+        for kw, intent in self._keywords.items():
+            if kw in lowered:
+                return intent, 0.8
+        return "UNKNOWN", 0.0
+
+
+# Singleton instance used by the router
+CLASSIFIER: BaseClassifier = DummyClassifier()

--- a/tests/osiris_tests/test_classifier.py
+++ b/tests/osiris_tests/test_classifier.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+# Load the classifier module without triggering osiris package imports
+_spec = importlib.util.spec_from_file_location(
+    "osiris.intent_classifier",
+    Path(__file__).resolve().parents[2] / "src/osiris/intent_classifier.py",
+)
+_classifier_module = importlib.util.module_from_spec(_spec)
+assert _spec.loader
+_spec.loader.exec_module(_classifier_module)
+CLASSIFIER = _classifier_module.CLASSIFIER
+
+
+def test_buy_intent() -> None:
+    intent, conf = CLASSIFIER.predict("please BUY the stock")
+    assert intent == "BUY"
+    assert conf == 0.8
+
+
+def test_sell_intent() -> None:
+    intent, conf = CLASSIFIER.predict("time to SELL everything")
+    assert intent == "SELL"
+    assert conf == 0.8
+
+
+def test_unknown_intent() -> None:
+    intent, conf = CLASSIFIER.predict("hold the line")
+    assert intent == "UNKNOWN"
+    assert conf == 0.0


### PR DESCRIPTION
## Summary
- add a minimal intent classification interface
- provide dummy keyword classifier
- tests for classifier behaviour

## Testing
- `python -m mypy src/osiris/intent_classifier.py --strict --follow-imports=skip --ignore-missing-imports`
- `pytest -q tests/osiris_tests/test_classifier.py`

------
https://chatgpt.com/codex/tasks/task_e_6868793c4054832f9270e4e033f45d25