### PR TITLE
fix: fakeredis shim for event bus tests

### DIFF
--- a/requirements-dgm-tests.txt
+++ b/requirements-dgm-tests.txt
@@ -9,7 +9,7 @@ pydantic>=2,<3
 
 # Redis shim + metrics
 redis==6.2.0
-fakeredis>=2.19
+fakeredis>=2.30
 prometheus-client
 
 # Misc utilities used by tests

--- a/tests/_shims/fake_aioredis.py
+++ b/tests/_shims/fake_aioredis.py
@@ -1,0 +1,21 @@
+"""Test-time shim for missing `FakeRedis.from_server`."""
+from __future__ import annotations
+
+from typing import Any
+
+import fakeredis
+
+# Patch fakeredis.aioredis if needed ----------------------------
+if not hasattr(fakeredis.aioredis.FakeRedis, "from_server"):
+    class _FakeRedis(fakeredis.aioredis.FakeRedis):  # type: ignore[misc]
+        @classmethod
+        def from_server(cls, server: Any, **kw: Any) -> "_FakeRedis":
+            return cls(decode_responses=kw.get("decode_responses", False))
+
+    fakeredis.aioredis.FakeRedis = _FakeRedis  # type: ignore[assignment]
+
+# Re-export patched objects ------------------------------------
+FakeRedis = fakeredis.aioredis.FakeRedis  # type: ignore[misc]
+FakeServer = fakeredis.aioredis.FakeServer
+
+__all__ = ["FakeRedis", "FakeServer"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,9 @@ from types import ModuleType, SimpleNamespace
 import typing as _t
 from hypothesis import settings
 
+# Provide compatibility shim for fakeredis
+import tests._shims.fake_aioredis  # noqa: F401
+
 settings.register_profile("ci", deadline=None)
 settings.load_profile("ci")
 


### PR DESCRIPTION
## Summary
- expose fake_aioredis shim with `from_server`
- load fakeredis shim in `tests/conftest.py`
- bump fakeredis and rely on shim for compatibility

## Testing
- `pip install -q -r requirements-dgm-tests.txt`
- `pytest tests/llm_sidecar_tests/test_event_bus.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686887af85f0832fbcaba4135138b39e