### PR TITLE
fix: export metrics registry and weighted choice

### DIFF
--- a/src/dgm_kernel/mutation_strategies.py
+++ b/src/dgm_kernel/mutation_strategies.py
@@ -17,8 +17,10 @@ import ast
 import random
 from typing import Any, Mapping, Protocol, Sequence, Type, cast
 
-from prometheus_client import CollectorRegistry, REGISTRY as DEFAULT_REGISTRY, Counter
+from prometheus_client import CollectorRegistry, Counter
 from . import metrics
+
+DEFAULT_REGISTRY = metrics.DEFAULT_REGISTRY
 
 DECAY = 0.995
 


### PR DESCRIPTION
## Summary
- expose `metrics.DEFAULT_REGISTRY` from the mutation strategy module
- reference the shared registry in weighted strategy selection

## Testing
- `pytest tests/dgm_kernel_tests/test_strategy_picker.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686887c2ac5c832f80285c27e5639bfc